### PR TITLE
Id b 33

### DIFF
--- a/PetFamily.Backend/src/Accounts/PetFamily.Accounts.Application/Commands/Register/RegisterUserHandler.cs
+++ b/PetFamily.Backend/src/Accounts/PetFamily.Accounts.Application/Commands/Register/RegisterUserHandler.cs
@@ -6,6 +6,7 @@ using PetFamily.Accounts.Application.Abstractions;
 using PetFamily.Accounts.Domain.DataModels;
 using PetFamily.Core.Abstractions;
 using PetFamily.Core.Dto.Volunteer;
+using PetFamily.SharedKernel.Constants;
 using PetFamily.SharedKernel.CustomErrors;
 using PetFamily.SharedKernel.Structs;
 using PetFamily.SharedKernel.ValueObjects;
@@ -42,7 +43,7 @@ public class RegisterUserHandler : ICommandHandler<string, RegisterUserCommand>
         CancellationToken cancellationToken)
     {
         
-        var participantRole = await _roleManager.FindByNameAsync(ParticipantAccount.PARTICIPANT)
+        var participantRole = await _roleManager.FindByNameAsync(DomainConstants.PARTICIPANT)
                         ?? throw new ApplicationException("Could not find participant role");
 
         var participant = User.CreateParticipant(

--- a/PetFamily.Backend/src/Accounts/PetFamily.Accounts.Contracts/ICreateVolunteerAccountContract.cs
+++ b/PetFamily.Backend/src/Accounts/PetFamily.Accounts.Contracts/ICreateVolunteerAccountContract.cs
@@ -1,0 +1,12 @@
+using CSharpFunctionalExtensions;
+using PetFamily.Accounts.Contracts.Requests;
+using PetFamily.SharedKernel.CustomErrors;
+
+namespace PetFamily.Accounts.Contracts;
+
+public interface ICreateVolunteerAccountContract
+{
+    public Task<Result<Guid, Error>> CreateVolunteerAccountAsync(
+        CreateVolunteerAccountRequest request,
+        CancellationToken cancellationToken = default);
+}

--- a/PetFamily.Backend/src/Accounts/PetFamily.Accounts.Contracts/Requests/CreateVolunteerAccountRequest.cs
+++ b/PetFamily.Backend/src/Accounts/PetFamily.Accounts.Contracts/Requests/CreateVolunteerAccountRequest.cs
@@ -1,0 +1,3 @@
+namespace PetFamily.Accounts.Contracts.Requests;
+
+public record CreateVolunteerAccountRequest(Guid UserId);

--- a/PetFamily.Backend/src/Accounts/PetFamily.Accounts.Domain/DataModels/AdminAccount.cs
+++ b/PetFamily.Backend/src/Accounts/PetFamily.Accounts.Domain/DataModels/AdminAccount.cs
@@ -2,8 +2,6 @@ namespace PetFamily.Accounts.Domain.DataModels;
 
 public class AdminAccount
 {
-    public const string ADMIN = "Admin";
-    
     public Guid Id { get; set; }
     
     public Guid UserId { get; set; } // navigation

--- a/PetFamily.Backend/src/Accounts/PetFamily.Accounts.Domain/DataModels/ParticipantAccount.cs
+++ b/PetFamily.Backend/src/Accounts/PetFamily.Accounts.Domain/DataModels/ParticipantAccount.cs
@@ -4,8 +4,6 @@ namespace PetFamily.Accounts.Domain.DataModels;
 
 public class ParticipantAccount
 {
-    public const string PARTICIPANT = "Participant";
-    
     public Guid Id { get; set; }
     
     public List<FavoritePetDto> FavoritePets { get; set; } = [];

--- a/PetFamily.Backend/src/Accounts/PetFamily.Accounts.Domain/DataModels/User.cs
+++ b/PetFamily.Backend/src/Accounts/PetFamily.Accounts.Domain/DataModels/User.cs
@@ -2,6 +2,7 @@ using CSharpFunctionalExtensions;
 using Microsoft.AspNetCore.Identity;
 using PetFamily.Core.Dto.Shared;
 using PetFamily.Core.Dto.Volunteer;
+using PetFamily.SharedKernel.Constants;
 using PetFamily.SharedKernel.CustomErrors;
 using PetFamily.SharedKernel.ValueObjects;
 
@@ -34,7 +35,7 @@ public class User : IdentityUser<Guid>
         FullName fullname,
         Role role)
     {
-        if (role.Name != DataModels.AdminAccount.ADMIN)
+        if (role.Name != DomainConstants.ADMIN)
             return Errors.General.ValueIsInvalid("role");
         
         var admin = new User()
@@ -54,7 +55,7 @@ public class User : IdentityUser<Guid>
         FullName fullname,
         Role role)
     {
-        if (role.Name != DataModels.ParticipantAccount.PARTICIPANT)
+        if (role.Name != DomainConstants.PARTICIPANT)
             return Errors.General.ValueIsInvalid("role");
         
         var participant = new User()

--- a/PetFamily.Backend/src/Accounts/PetFamily.Accounts.Domain/DataModels/VolunteerAccount.cs
+++ b/PetFamily.Backend/src/Accounts/PetFamily.Accounts.Domain/DataModels/VolunteerAccount.cs
@@ -6,8 +6,6 @@ namespace PetFamily.Accounts.Domain.DataModels;
 
 public class VolunteerAccount
 {
-    public const string VOLUNTEER = "Volunteer";
-    
     public Guid Id { get; set; }
 
     public int Experience { get; set; } = 0;

--- a/PetFamily.Backend/src/Accounts/PetFamily.Accounts.Infrastructure/Seeding/AccountsSeederService.cs
+++ b/PetFamily.Backend/src/Accounts/PetFamily.Accounts.Infrastructure/Seeding/AccountsSeederService.cs
@@ -69,7 +69,7 @@ public class AccountsSeederService
     {
         var AdminFullName = FullName.Create("AdminFirstName", "AdminLastName", "AdminSurname").Value;
         
-        var adminRole = await _roleManager.FindByNameAsync(AdminAccount.ADMIN)
+        var adminRole = await _roleManager.FindByNameAsync(DomainConstants.ADMIN)
                         ?? throw new ApplicationException("Could not find admin role");
         
         var adminUser = User.CreateAdmin(

--- a/PetFamily.Backend/src/Accounts/PetFamily.Accounts.Presentation/Contracts/CreateVolunteerAccountContract.cs
+++ b/PetFamily.Backend/src/Accounts/PetFamily.Accounts.Presentation/Contracts/CreateVolunteerAccountContract.cs
@@ -1,0 +1,76 @@
+using CSharpFunctionalExtensions;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using PetFamily.Accounts.Application.Abstractions;
+using PetFamily.Accounts.Contracts;
+using PetFamily.Accounts.Contracts.Requests;
+using PetFamily.Accounts.Domain.DataModels;
+using PetFamily.Core.Abstractions;
+using PetFamily.SharedKernel.Constants;
+using PetFamily.SharedKernel.CustomErrors;
+using PetFamily.SharedKernel.Structs;
+
+namespace PetFamily.Accounts.Presentation.Contracts;
+
+public class CreateVolunteerAccountContract : ICreateVolunteerAccountContract
+{
+    private readonly UserManager<User> _userManager;
+    private readonly IAccountManager _accountManager;
+    private readonly RoleManager<Role> _roleManager;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly ILogger<CreateVolunteerAccountContract> _logger;
+
+    public CreateVolunteerAccountContract(
+        UserManager<User> userManager,
+        IAccountManager accountManager,
+        RoleManager<Role> roleManager,
+        [FromKeyedServices(UnitOfWorkSelector.Accounts)]
+        IUnitOfWork unitOfWork,
+        ILogger<CreateVolunteerAccountContract> logger)
+    {
+        _userManager = userManager;
+        _accountManager = accountManager;
+        _roleManager = roleManager;
+        _unitOfWork = unitOfWork;
+        _logger = logger;
+    }
+
+    public async Task<Result<Guid, Error>> CreateVolunteerAccountAsync(
+        CreateVolunteerAccountRequest request,
+        CancellationToken cancellationToken)
+    {
+        var user = await _userManager.Users.FirstOrDefaultAsync(u => u.Id == request.UserId, cancellationToken);
+        if (user is null)
+            return Errors.General.ValueNotFound(request.UserId);
+
+        var role = await _roleManager.FindByNameAsync(DomainConstants.VOLUNTEER);
+        if (role is null)
+            return Errors.General.ValueNotFound(DomainConstants.VOLUNTEER);
+
+        using var transaction = await _unitOfWork.BeginTransactionAsync(cancellationToken);
+
+        try
+        {
+            var roleResult = await _userManager.AddToRoleAsync(user, role.Name);
+            if (!roleResult.Succeeded)
+                return Errors.General.Failure("Failed to add role to user");
+
+            var volunteerAccount = new VolunteerAccount(user);
+            await _accountManager.CreateVolunteerAccount(volunteerAccount);
+            
+            _logger.LogInformation("Created volunteer account for user with id = {ID}", request.UserId);
+
+            transaction.Commit();
+
+            return volunteerAccount.Id;
+        }
+        catch (Exception ex)
+        {
+            transaction.Rollback();
+            _logger.LogError(ex, "Failed to create volunteer account");
+            return Errors.General.Failure("Transaction failed");
+        }
+    }
+}

--- a/PetFamily.Backend/src/Accounts/PetFamily.Accounts.Presentation/DependencyInjection.cs
+++ b/PetFamily.Backend/src/Accounts/PetFamily.Accounts.Presentation/DependencyInjection.cs
@@ -9,6 +9,7 @@ public static class DependencyInjection
     public static IServiceCollection AddAccountsContracts(this IServiceCollection services)
     {
         services.AddScoped<IGetUserPermissionCodesContract, GetUserPermissionCodesContract>();
+        services.AddScoped<ICreateVolunteerAccountContract, CreateVolunteerAccountContract>();
         return services;
     }
 }

--- a/PetFamily.Backend/src/Discussions/PetFamily.Discussions.Application/Abstractions/IDiscussionsRepository.cs
+++ b/PetFamily.Backend/src/Discussions/PetFamily.Discussions.Application/Abstractions/IDiscussionsRepository.cs
@@ -14,5 +14,11 @@ public interface IDiscussionsRepository
     
      Guid Delete(Discussion discussion, CancellationToken cancellationToken = default);
     
-     Task<Result<Discussion, Error>> GetByIdAsync(DiscussionId id, CancellationToken cancellationToken = default);
+     Task<Result<Discussion, Error>> GetByIdAsync(
+         DiscussionId id,
+         CancellationToken cancellationToken = default);
+     
+     Task<Result<Discussion, Error>> GetByRelationIdAsync(
+          RelationId relationId,
+          CancellationToken cancellationToken = default);
 }

--- a/PetFamily.Backend/src/Discussions/PetFamily.Discussions.Application/Commands/CreateDiscussionCommand.cs
+++ b/PetFamily.Backend/src/Discussions/PetFamily.Discussions.Application/Commands/CreateDiscussionCommand.cs
@@ -1,0 +1,5 @@
+using PetFamily.Core.Abstractions;
+
+namespace PetFamily.Discussions.Application.Commands;
+
+public record CreateDiscussionCommand(Guid RelationId, List<Guid> UserIds) : ICommand;

--- a/PetFamily.Backend/src/Discussions/PetFamily.Discussions.Application/Commands/CreateDiscussionHandler.cs
+++ b/PetFamily.Backend/src/Discussions/PetFamily.Discussions.Application/Commands/CreateDiscussionHandler.cs
@@ -1,0 +1,60 @@
+using CSharpFunctionalExtensions;
+using FluentValidation;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using PetFamily.Core.Abstractions;
+using PetFamily.Core.Extensions;
+using PetFamily.Discussions.Application.Abstractions;
+using PetFamily.Discussions.Domain.Entities;
+using PetFamily.SharedKernel.CustomErrors;
+using PetFamily.SharedKernel.Structs;
+using PetFamily.SharedKernel.ValueObjects.Ids;
+
+namespace PetFamily.Discussions.Application.Commands;
+
+public class CreateDiscussionHandler : ICommandHandler<Guid, CreateDiscussionCommand>
+{
+    private readonly IDiscussionsRepository _discussionsRepository;
+    private readonly ILogger<CreateDiscussionHandler> _logger;
+    private readonly IValidator<CreateDiscussionCommand> _validator;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public CreateDiscussionHandler(
+        IDiscussionsRepository discussionsRepository,
+        ILogger<CreateDiscussionHandler> logger,
+        IValidator<CreateDiscussionCommand> validator,
+        [FromKeyedServices(UnitOfWorkSelector.Discussions)]
+        IUnitOfWork unitOfWork)
+    {
+        _discussionsRepository = discussionsRepository;
+        _logger = logger;
+        _validator = validator;
+        _unitOfWork = unitOfWork;
+    }
+
+    public async Task<Result<Guid, ErrorList>> HandleAsync(
+        CreateDiscussionCommand command,
+        CancellationToken cancellationToken)
+    {
+        var validationResult = await _validator.ValidateAsync(command, cancellationToken);
+        if (validationResult.IsValid == false)
+            return validationResult.ToErrorList();
+
+        var relationId = RelationId.Create(command.RelationId);
+
+        var userIds = command.UserIds.Select(UserId.Create).ToList();
+
+        var discussion = Discussion.Create(relationId, userIds);
+        
+        if (discussion.IsFailure)
+            return discussion.Error.ToErrorList();
+        
+        await _discussionsRepository.AddAsync(discussion.Value, cancellationToken);
+        await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "Created discussion with Id = {id}", discussion.Value.Id.Value);
+
+        return discussion.Value.Id.Value;
+    }
+}

--- a/PetFamily.Backend/src/Discussions/PetFamily.Discussions.Application/Commands/CreateDiscussionHandler.cs
+++ b/PetFamily.Backend/src/Discussions/PetFamily.Discussions.Application/Commands/CreateDiscussionHandler.cs
@@ -46,7 +46,7 @@ public class CreateDiscussionHandler : ICommandHandler<Guid, CreateDiscussionCom
 
         var existedDiscussion = await _discussionsRepository.GetByRelationIdAsync(relationId, cancellationToken);
         if (existedDiscussion.IsSuccess)
-            return existedDiscussion.Value.Id.Value;
+            return Errors.General.AlreadyExist("Discussion with such relationId already exists").ToErrorList();
         
         var discussion = Discussion.Create(relationId, userIds);
         

--- a/PetFamily.Backend/src/Discussions/PetFamily.Discussions.Application/Commands/CreateDiscussionHandler.cs
+++ b/PetFamily.Backend/src/Discussions/PetFamily.Discussions.Application/Commands/CreateDiscussionHandler.cs
@@ -44,6 +44,10 @@ public class CreateDiscussionHandler : ICommandHandler<Guid, CreateDiscussionCom
 
         var userIds = command.UserIds.Select(UserId.Create).ToList();
 
+        var existedDiscussion = await _discussionsRepository.GetByRelationIdAsync(relationId, cancellationToken);
+        if (existedDiscussion.IsSuccess)
+            return existedDiscussion.Value.Id.Value;
+        
         var discussion = Discussion.Create(relationId, userIds);
         
         if (discussion.IsFailure)

--- a/PetFamily.Backend/src/Discussions/PetFamily.Discussions.Application/Commands/CreateDiscussionValidator.cs
+++ b/PetFamily.Backend/src/Discussions/PetFamily.Discussions.Application/Commands/CreateDiscussionValidator.cs
@@ -1,0 +1,17 @@
+using FluentValidation;
+using PetFamily.Core.Extensions;
+using PetFamily.SharedKernel.CustomErrors;
+
+namespace PetFamily.Discussions.Application.Commands;
+
+public class CreateDiscussionCommandValidator : AbstractValidator<CreateDiscussionCommand>
+{
+    public CreateDiscussionCommandValidator()
+    {
+        RuleFor(c => c.RelationId)
+            .NotEmpty().WithError(Errors.General.ValueIsRequired("RelationId"));
+        
+        RuleForEach(c => c.UserIds)
+            .NotEmpty().WithError(Errors.General.ValueIsRequired("UserId"));
+    }
+}

--- a/PetFamily.Backend/src/Discussions/PetFamily.Discussions.Application/PetFamily.Discussions.Application.csproj
+++ b/PetFamily.Backend/src/Discussions/PetFamily.Discussions.Application/PetFamily.Discussions.Application.csproj
@@ -11,7 +11,6 @@
     </ItemGroup>
 
     <ItemGroup>
-      <Folder Include="Commands\" />
       <Folder Include="Queries\" />
     </ItemGroup>
 

--- a/PetFamily.Backend/src/Discussions/PetFamily.Discussions.Contracts/ICloseDiscussionContract.cs
+++ b/PetFamily.Backend/src/Discussions/PetFamily.Discussions.Contracts/ICloseDiscussionContract.cs
@@ -1,0 +1,13 @@
+using CSharpFunctionalExtensions;
+using PetFamily.Discussions.Contracts.Requests;
+using PetFamily.SharedKernel.CustomErrors;
+
+namespace PetFamily.Discussions.Contracts;
+
+
+public interface ICloseDiscussionContract
+{
+    public Task<Result<Guid, Error>> CloseDiscussion(
+        CloseDiscussionRequest request,
+        CancellationToken cancellationToken);
+}

--- a/PetFamily.Backend/src/Discussions/PetFamily.Discussions.Contracts/ICreateDiscussionContract.cs
+++ b/PetFamily.Backend/src/Discussions/PetFamily.Discussions.Contracts/ICreateDiscussionContract.cs
@@ -1,0 +1,12 @@
+using CSharpFunctionalExtensions;
+using PetFamily.Discussions.Contracts.Requests;
+using PetFamily.SharedKernel.CustomErrors;
+
+namespace PetFamily.Discussions.Contracts;
+
+public interface ICreateDiscussionContract
+{
+    public Task<Result<Guid, ErrorList>> CreateDiscussion(
+        CreateDiscussionRequest request,
+        CancellationToken cancellationToken);
+}

--- a/PetFamily.Backend/src/Discussions/PetFamily.Discussions.Contracts/PetFamily.Discussions.Contracts.csproj
+++ b/PetFamily.Backend/src/Discussions/PetFamily.Discussions.Contracts/PetFamily.Discussions.Contracts.csproj
@@ -11,8 +11,4 @@
       <ProjectReference Include="..\..\Shared\PetFamily.SharedKernel\PetFamily.SharedKernel.csproj" />
     </ItemGroup>
 
-    <ItemGroup>
-      <Folder Include="Requests\" />
-    </ItemGroup>
-
 </Project>

--- a/PetFamily.Backend/src/Discussions/PetFamily.Discussions.Contracts/Requests/CloseDiscussionRequest.cs
+++ b/PetFamily.Backend/src/Discussions/PetFamily.Discussions.Contracts/Requests/CloseDiscussionRequest.cs
@@ -1,0 +1,3 @@
+namespace PetFamily.Discussions.Contracts.Requests;
+
+public record CloseDiscussionRequest(Guid RelationId);

--- a/PetFamily.Backend/src/Discussions/PetFamily.Discussions.Contracts/Requests/CreateDiscussionRequest.cs
+++ b/PetFamily.Backend/src/Discussions/PetFamily.Discussions.Contracts/Requests/CreateDiscussionRequest.cs
@@ -1,0 +1,3 @@
+namespace PetFamily.Discussions.Contracts.Requests;
+
+public record CreateDiscussionRequest(Guid RelationId, List<Guid> UserIds);

--- a/PetFamily.Backend/src/Discussions/PetFamily.Discussions.Infrastructure/Configurations/Write/DiscussionConfiguration.cs
+++ b/PetFamily.Backend/src/Discussions/PetFamily.Discussions.Infrastructure/Configurations/Write/DiscussionConfiguration.cs
@@ -32,9 +32,7 @@ public class DiscussionConfiguration : IEntityTypeConfiguration<Discussion>
         {
             sb.Property(s => s.Value)
                 .IsRequired()
-                .HasConversion(
-                    status => (int)status,
-                    status => (DiscussionStatusEnum)status)
+                .HasConversion<string>()
                 .HasColumnName("status");
         });
 

--- a/PetFamily.Backend/src/Discussions/PetFamily.Discussions.Infrastructure/Repositories/DiscussionsRepository.cs
+++ b/PetFamily.Backend/src/Discussions/PetFamily.Discussions.Infrastructure/Repositories/DiscussionsRepository.cs
@@ -47,4 +47,18 @@ public class DiscussionsRepository : IDiscussionsRepository
 
         return discussion;
     }
+    
+    public async Task<Result<Discussion, Error>> GetByRelationIdAsync(
+        RelationId relationId,
+        CancellationToken cancellationToken = default)
+    {
+        var discussion = await _context.Discussions
+            .Include(d => d.Messages)
+            .FirstOrDefaultAsync(v => v.RelationId == relationId, cancellationToken);
+        
+        if (discussion == null)
+            return Errors.General.ValueNotFound();
+
+        return discussion;
+    }
 }

--- a/PetFamily.Backend/src/Discussions/PetFamily.Discussions.Presentation/Contracts/CloseDiscussionContract.cs
+++ b/PetFamily.Backend/src/Discussions/PetFamily.Discussions.Presentation/Contracts/CloseDiscussionContract.cs
@@ -1,0 +1,41 @@
+using CSharpFunctionalExtensions;
+using Microsoft.Extensions.DependencyInjection;
+using PetFamily.Core.Abstractions;
+using PetFamily.Discussions.Application.Abstractions;
+using PetFamily.Discussions.Contracts;
+using PetFamily.Discussions.Contracts.Requests;
+using PetFamily.SharedKernel.CustomErrors;
+using PetFamily.SharedKernel.Structs;
+
+namespace PetFamily.Discussions.Presentation.Contracts;
+
+public class CloseDiscussionContract : ICloseDiscussionContract
+{
+    private readonly IDiscussionsRepository _discussionsRepository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public CloseDiscussionContract(
+        IDiscussionsRepository discussionsRepository,
+        [FromKeyedServices(UnitOfWorkSelector.Discussions)]
+        IUnitOfWork unitOfWork)
+    {
+        _discussionsRepository = discussionsRepository;
+        _unitOfWork = unitOfWork;
+    }
+
+    public async Task<Result<Guid, Error>> CloseDiscussion(
+        CloseDiscussionRequest request,
+        CancellationToken cancellationToken)
+    {
+        var discussion = await _discussionsRepository
+            .GetByRelationIdAsync(request.RelationId, cancellationToken);
+
+        if (discussion.IsFailure)
+            return discussion.Error;
+
+        discussion.Value.Close();
+        await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+        return discussion.Value.Id.Value;
+    }
+}

--- a/PetFamily.Backend/src/Discussions/PetFamily.Discussions.Presentation/Contracts/CreateDiscussionContract.cs
+++ b/PetFamily.Backend/src/Discussions/PetFamily.Discussions.Presentation/Contracts/CreateDiscussionContract.cs
@@ -1,0 +1,32 @@
+using CSharpFunctionalExtensions;
+using PetFamily.Discussions.Application.Commands;
+using PetFamily.Discussions.Contracts;
+using PetFamily.Discussions.Contracts.Requests;
+using PetFamily.Discussions.Domain.Entities;
+using PetFamily.SharedKernel.CustomErrors;
+
+namespace PetFamily.Discussions.Presentation.Contracts;
+
+public class CreateDiscussionContract : ICreateDiscussionContract
+{
+    private readonly CreateDiscussionHandler _handler;
+
+    public CreateDiscussionContract(CreateDiscussionHandler handler)
+    {
+        _handler = handler;
+    }
+
+    public async Task<Result<Guid, ErrorList>> CreateDiscussion(
+        CreateDiscussionRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var command = new CreateDiscussionCommand(request.RelationId, request.UserIds);
+        
+        var result = await _handler.HandleAsync(command, cancellationToken);
+
+        if (result.IsFailure)
+            return result.Error;
+
+        return result.Value;
+    }
+}

--- a/PetFamily.Backend/src/Discussions/PetFamily.Discussions.Presentation/DependencyInjection.cs
+++ b/PetFamily.Backend/src/Discussions/PetFamily.Discussions.Presentation/DependencyInjection.cs
@@ -10,6 +10,7 @@ public static class DependencyInjection
     public static IServiceCollection AddDiscussionsContracts(this IServiceCollection services)
     {
         services.AddScoped<ICreateDiscussionContract, CreateDiscussionContract>();
+        services.AddScoped<ICloseDiscussionContract, CloseDiscussionContract>();
         return services;
     }
 }

--- a/PetFamily.Backend/src/Discussions/PetFamily.Discussions.Presentation/DependencyInjection.cs
+++ b/PetFamily.Backend/src/Discussions/PetFamily.Discussions.Presentation/DependencyInjection.cs
@@ -1,4 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+using PetFamily.Discussions.Contracts;
+using PetFamily.Discussions.Presentation.Contracts;
 
 namespace PetFamily.Discussions.Presentation;
 
@@ -7,6 +9,7 @@ public static class DependencyInjection
 {
     public static IServiceCollection AddDiscussionsContracts(this IServiceCollection services)
     {
+        services.AddScoped<ICreateDiscussionContract, CreateDiscussionContract>();
         return services;
     }
 }

--- a/PetFamily.Backend/src/Discussions/PetFamily.Discussions.Presentation/PetFamily.Discussions.Presentation.csproj
+++ b/PetFamily.Backend/src/Discussions/PetFamily.Discussions.Presentation/PetFamily.Discussions.Presentation.csproj
@@ -16,7 +16,6 @@
     </ItemGroup>
 
     <ItemGroup>
-      <Folder Include="Contracts\" />
       <Folder Include="Discussions\Requests\" />
     </ItemGroup>
 

--- a/PetFamily.Backend/src/PetFamily.Web/etc/accounts.json
+++ b/PetFamily.Backend/src/PetFamily.Web/etc/accounts.json
@@ -7,7 +7,8 @@
       "volunteerRequests.CreateRequest",
       "volunteerRequests.TakeRequestOnReview",
       "volunteerRequests.RequireRevision",
-      "volunteerRequests.AmendRequest"
+      "volunteerRequests.AmendRequest",
+      "volunteerRequests.ApproveRequest"
     ],
     "Volunteers": [
       "volunteers.AddPet",
@@ -101,7 +102,8 @@
       "species.GetBreedsBySpeciesId",
       "species.GetSpeciesWithPagination",
       "volunteerRequests.TakeRequestOnReview",
-      "volunteerRequests.RequireRevision"
+      "volunteerRequests.RequireRevision",
+      "volunteerRequests.ApproveRequest"
     ]
   }
 }

--- a/PetFamily.Backend/src/PetFamily.Web/etc/accounts.json
+++ b/PetFamily.Backend/src/PetFamily.Web/etc/accounts.json
@@ -4,7 +4,8 @@
       "users.UpdateSocialNetworks"
     ],
     "VolunteerRequests" : [
-      "volunteerRequests.CreateRequest"
+      "volunteerRequests.CreateRequest",
+      "volunteerRequests.TakeRequestOnReview"
     ],
     "Volunteers": [
       "volunteers.AddPet",
@@ -95,7 +96,8 @@
       "species.DeleteBreedById",
       "species.DeleteSpeciesById",
       "species.GetBreedsBySpeciesId",
-      "species.GetSpeciesWithPagination"
+      "species.GetSpeciesWithPagination",
+      "volunteerRequests.TakeRequestOnReview"
     ]
   }
 }

--- a/PetFamily.Backend/src/PetFamily.Web/etc/accounts.json
+++ b/PetFamily.Backend/src/PetFamily.Web/etc/accounts.json
@@ -1,7 +1,10 @@
 {
   "Permissions": {
-    "users" : [
+    "Users" : [
       "users.UpdateSocialNetworks"
+    ],
+    "VolunteerRequests" : [
+      "volunteerRequests.CreateRequest"
     ],
     "Volunteers": [
       "volunteers.AddPet",
@@ -41,7 +44,8 @@
       "volunteers.GetVolunteerById",
       "volunteers.GetVolunteersWithPagination",
       "species.GetBreedsBySpeciesId",
-      "species.GetSpeciesWithPagination"
+      "species.GetSpeciesWithPagination",
+      "volunteerRequests.CreateRequest"
     ],
     "Volunteer": [
       "users.UpdateSocialNetworks",

--- a/PetFamily.Backend/src/PetFamily.Web/etc/accounts.json
+++ b/PetFamily.Backend/src/PetFamily.Web/etc/accounts.json
@@ -6,7 +6,8 @@
     "VolunteerRequests" : [
       "volunteerRequests.CreateRequest",
       "volunteerRequests.TakeRequestOnReview",
-      "volunteerRequests.RequireRevision"
+      "volunteerRequests.RequireRevision",
+      "volunteerRequests.AmendRequest"
     ],
     "Volunteers": [
       "volunteers.AddPet",
@@ -47,7 +48,8 @@
       "volunteers.GetVolunteersWithPagination",
       "species.GetBreedsBySpeciesId",
       "species.GetSpeciesWithPagination",
-      "volunteerRequests.CreateRequest"
+      "volunteerRequests.CreateRequest",
+      "volunteerRequests.AmendRequest"
     ],
     "Volunteer": [
       "users.UpdateSocialNetworks",

--- a/PetFamily.Backend/src/PetFamily.Web/etc/accounts.json
+++ b/PetFamily.Backend/src/PetFamily.Web/etc/accounts.json
@@ -10,7 +10,8 @@
       "volunteerRequests.AmendRequest",
       "volunteerRequests.ApproveRequest",
       "volunteerRequests.RejectRequest",
-      "volunteerRequests.GetUnhandledRequests"
+      "volunteerRequests.GetUnhandledRequests",
+      "volunteerRequests.GetHandledRequestsByAdminId"
     ],
     "Volunteers": [
       "volunteers.AddPet",
@@ -107,7 +108,8 @@
       "volunteerRequests.RequireRevision",
       "volunteerRequests.ApproveRequest",
       "volunteerRequests.RejectRequest",
-      "volunteerRequests.GetUnhandledRequests"
+      "volunteerRequests.GetUnhandledRequests",
+      "volunteerRequests.GetHandledRequestsByAdminId"
     ]
   }
 }

--- a/PetFamily.Backend/src/PetFamily.Web/etc/accounts.json
+++ b/PetFamily.Backend/src/PetFamily.Web/etc/accounts.json
@@ -9,7 +9,8 @@
       "volunteerRequests.RequireRevision",
       "volunteerRequests.AmendRequest",
       "volunteerRequests.ApproveRequest",
-      "volunteerRequests.RejectRequest"
+      "volunteerRequests.RejectRequest",
+      "volunteerRequests.GetUnhandledRequests"
     ],
     "Volunteers": [
       "volunteers.AddPet",
@@ -105,7 +106,8 @@
       "volunteerRequests.TakeRequestOnReview",
       "volunteerRequests.RequireRevision",
       "volunteerRequests.ApproveRequest",
-      "volunteerRequests.RejectRequest"
+      "volunteerRequests.RejectRequest",
+      "volunteerRequests.GetUnhandledRequests"
     ]
   }
 }

--- a/PetFamily.Backend/src/PetFamily.Web/etc/accounts.json
+++ b/PetFamily.Backend/src/PetFamily.Web/etc/accounts.json
@@ -11,7 +11,8 @@
       "volunteerRequests.ApproveRequest",
       "volunteerRequests.RejectRequest",
       "volunteerRequests.GetUnhandledRequests",
-      "volunteerRequests.GetHandledRequestsByAdminId"
+      "volunteerRequests.GetHandledRequestsByAdminId",
+      "volunteerRequests.GetRequestsByUserId"
     ],
     "Volunteers": [
       "volunteers.AddPet",
@@ -53,7 +54,8 @@
       "species.GetBreedsBySpeciesId",
       "species.GetSpeciesWithPagination",
       "volunteerRequests.CreateRequest",
-      "volunteerRequests.AmendRequest"
+      "volunteerRequests.AmendRequest",
+      "volunteerRequests.GetRequestsByUserId"
     ],
     "Volunteer": [
       "users.UpdateSocialNetworks",

--- a/PetFamily.Backend/src/PetFamily.Web/etc/accounts.json
+++ b/PetFamily.Backend/src/PetFamily.Web/etc/accounts.json
@@ -8,7 +8,8 @@
       "volunteerRequests.TakeRequestOnReview",
       "volunteerRequests.RequireRevision",
       "volunteerRequests.AmendRequest",
-      "volunteerRequests.ApproveRequest"
+      "volunteerRequests.ApproveRequest",
+      "volunteerRequests.RejectRequest"
     ],
     "Volunteers": [
       "volunteers.AddPet",
@@ -103,7 +104,8 @@
       "species.GetSpeciesWithPagination",
       "volunteerRequests.TakeRequestOnReview",
       "volunteerRequests.RequireRevision",
-      "volunteerRequests.ApproveRequest"
+      "volunteerRequests.ApproveRequest",
+      "volunteerRequests.RejectRequest"
     ]
   }
 }

--- a/PetFamily.Backend/src/PetFamily.Web/etc/accounts.json
+++ b/PetFamily.Backend/src/PetFamily.Web/etc/accounts.json
@@ -5,7 +5,8 @@
     ],
     "VolunteerRequests" : [
       "volunteerRequests.CreateRequest",
-      "volunteerRequests.TakeRequestOnReview"
+      "volunteerRequests.TakeRequestOnReview",
+      "volunteerRequests.RequireRevision"
     ],
     "Volunteers": [
       "volunteers.AddPet",
@@ -97,7 +98,8 @@
       "species.DeleteSpeciesById",
       "species.GetBreedsBySpeciesId",
       "species.GetSpeciesWithPagination",
-      "volunteerRequests.TakeRequestOnReview"
+      "volunteerRequests.TakeRequestOnReview",
+      "volunteerRequests.RequireRevision"
     ]
   }
 }

--- a/PetFamily.Backend/src/Shared/PetFamily.Core/Dto/VolunteerRequest/VolunteerRequestDto.cs
+++ b/PetFamily.Backend/src/Shared/PetFamily.Core/Dto/VolunteerRequest/VolunteerRequestDto.cs
@@ -1,0 +1,13 @@
+namespace PetFamily.Core.Dto.VolunteerRequest;
+
+public class VolunteerRequestDto
+{
+    public Guid Id { get; set; }
+    public Guid? AdminId { get; set; }
+    public Guid UserId { get; set; }
+    public string VolunteerInfo { get; set; }
+    public string Status { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public string? RevisionComment { get; set; }
+    public DateTime? RejectedAt { get; set; }
+}

--- a/PetFamily.Backend/src/Shared/PetFamily.Framework/ApplicationController.cs
+++ b/PetFamily.Backend/src/Shared/PetFamily.Framework/ApplicationController.cs
@@ -1,5 +1,8 @@
+using CSharpFunctionalExtensions;
 using Microsoft.AspNetCore.Mvc;
+using PetFamily.Core;
 using PetFamily.Core.Models;
+using PetFamily.SharedKernel.CustomErrors;
 
 namespace PetFamily.Framework;
 
@@ -12,5 +15,28 @@ public abstract class ApplicationController : ControllerBase
         var envelope = Envelope.Ok(value);
         
         return new OkObjectResult(envelope);
+    }
+
+    protected Result<Guid, Error> GetUserId()
+    {
+        var claimId = HttpContext.User.Claims.FirstOrDefault(c => c.Type == CustomClaims.Id);
+        if (claimId == null)
+            return Errors.General.ValueNotFound("claimId");
+
+        var parseResult = Guid.TryParse(claimId.Value, out var userId);
+        if (!parseResult)
+            return Errors.General.ValueIsInvalid("userId");
+        
+        return userId;
+    }
+
+    protected UnitResult<Error> CheckExclusiveRole(string roleName)
+    {
+        var roles = HttpContext.User.Claims.Where(c => c.Type == CustomClaims.Role);
+        if (roles.Any(r => r.Value == roleName) && roles.Count() == 1)
+            return UnitResult.Success<Error>();
+
+        return Errors.General
+            .Conflict($"user should not have any other role then {roleName} in order to use this feature");
     }
 }

--- a/PetFamily.Backend/src/Shared/PetFamily.SharedKernel/Constants/DomainConstants.cs
+++ b/PetFamily.Backend/src/Shared/PetFamily.SharedKernel/Constants/DomainConstants.cs
@@ -11,4 +11,8 @@ public static class DomainConstants
     public const int MAX_EXTENSION_LENGTH = 10;
     public const int MAX_PATH_LENGTH = 30;
     public const int MAX_FILE_SIZE_IN_BYTES = 6000000;
+
+    public const string ADMIN = "Admin";
+    public const string VOLUNTEER = "Volunteer";
+    public const string PARTICIPANT = "Participant";
 }

--- a/PetFamily.Backend/src/Shared/PetFamily.SharedKernel/CustomErrors/Errors.cs
+++ b/PetFamily.Backend/src/Shared/PetFamily.SharedKernel/CustomErrors/Errors.cs
@@ -48,6 +48,11 @@ public static class Errors
         {
             return Error.Failure(code, $"{message}");
         }
+        
+        public static Error Failure(string? message)
+        {
+            return Error.Failure("server.internal", $"{message}");
+        }
 
         public static Error AlreadyExist(string? message)
         {

--- a/PetFamily.Backend/src/Shared/PetFamily.SharedKernel/CustomErrors/Errors.cs
+++ b/PetFamily.Backend/src/Shared/PetFamily.SharedKernel/CustomErrors/Errors.cs
@@ -52,10 +52,9 @@ public static class Errors
         public static Error AlreadyExist(string? message)
         {
             var text = message ?? "record";
-            return Error.Validation("record.already_exist", $"{text} already exist");
+            return Error.Validation("record.already.exist", $"{text} already exist");
         }
-
-
+        
         public static Error LengthIsInvalid(int lessThen, string? propertyName = null)
         {
             var text = propertyName ?? ""; 

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Abstractions/IReadDbContext.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Abstractions/IReadDbContext.cs
@@ -1,0 +1,8 @@
+using PetFamily.Core.Dto.VolunteerRequest;
+
+namespace PetFamily.VolunteerRequests.Application.Abstractions;
+
+public interface IReadDbContext
+{
+    IQueryable<VolunteerRequestDto> VolunteerRequests { get; }
+}

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Abstractions/IVolunteerRequestsRepository.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Abstractions/IVolunteerRequestsRepository.cs
@@ -18,7 +18,7 @@ public interface IVolunteerRequestsRepository
         VolunteerRequestId id,
         CancellationToken cancellationToken = default);
     
-    Task<Result<VolunteerRequest, Error>> GetByUserIdAsync(
+    Task<List<VolunteerRequest>> GetRequestsByUserIdAsync(
         UserId id,
         CancellationToken cancellationToken = default);
 }

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Abstractions/IVolunteerRequestsRepository.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Abstractions/IVolunteerRequestsRepository.cs
@@ -15,4 +15,8 @@ public interface IVolunteerRequestsRepository
     Guid Delete(VolunteerRequest volunteerRequest, CancellationToken cancellationToken = default);
     
     Task<Result<VolunteerRequest, Error>> GetByIdAsync(VolunteerRequestId id, CancellationToken cancellationToken = default);
+    
+    Task<Result<VolunteerRequest, Error>> GetByUserIdAsync(
+        UserId id,
+        CancellationToken cancellationToken = default);
 }

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Abstractions/IVolunteerRequestsRepository.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Abstractions/IVolunteerRequestsRepository.cs
@@ -14,7 +14,9 @@ public interface IVolunteerRequestsRepository
     
     Guid Delete(VolunteerRequest volunteerRequest, CancellationToken cancellationToken = default);
     
-    Task<Result<VolunteerRequest, Error>> GetByIdAsync(VolunteerRequestId id, CancellationToken cancellationToken = default);
+    Task<Result<VolunteerRequest, Error>> GetByIdAsync(
+        VolunteerRequestId id,
+        CancellationToken cancellationToken = default);
     
     Task<Result<VolunteerRequest, Error>> GetByUserIdAsync(
         UserId id,

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/AmendRequest/AmendRequestCommand.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/AmendRequest/AmendRequestCommand.cs
@@ -1,0 +1,5 @@
+using PetFamily.Core.Abstractions;
+
+namespace PetFamily.VolunteerRequests.Application.Commands.AmendRequest;
+
+public record AmendRequestCommand(Guid RequestId, Guid UserId, string UpdatedInfo) : ICommand;

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/AmendRequest/AmendRequestHandler.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/AmendRequest/AmendRequestHandler.cs
@@ -1,0 +1,71 @@
+using CSharpFunctionalExtensions;
+using FluentValidation;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using PetFamily.Core.Abstractions;
+using PetFamily.Core.Extensions;
+using PetFamily.SharedKernel.CustomErrors;
+using PetFamily.SharedKernel.Structs;
+using PetFamily.SharedKernel.ValueObjects.Ids;
+using PetFamily.VolunteerRequests.Application.Abstractions;
+using PetFamily.VolunteerRequests.Domain.ValueObjects;
+
+namespace PetFamily.VolunteerRequests.Application.Commands.AmendRequest;
+
+public class AmendRequestHandler : ICommandHandler<Guid, AmendRequestCommand>
+{
+    private readonly IVolunteerRequestsRepository _volunteerRequestsRepository;
+    private readonly ILogger<AmendRequestHandler> _logger;
+    private readonly IValidator<AmendRequestCommand> _validator;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public AmendRequestHandler(
+        IVolunteerRequestsRepository volunteerRequestsRepository,
+        ILogger<AmendRequestHandler> logger,
+        IValidator<AmendRequestCommand> validator,
+        [FromKeyedServices(UnitOfWorkSelector.VolunteerRequests)]
+        IUnitOfWork unitOfWork)
+    {
+        _volunteerRequestsRepository = volunteerRequestsRepository;
+        _logger = logger;
+        _validator = validator;
+        _unitOfWork = unitOfWork;
+    }
+
+    public async Task<Result<Guid, ErrorList>> HandleAsync(
+        AmendRequestCommand command,
+        CancellationToken cancellationToken)
+    {
+        var validationResult = await _validator.ValidateAsync(command, cancellationToken);
+        if (validationResult.IsValid == false)
+            return validationResult.ToErrorList();
+
+        var requestId = VolunteerRequestId.Create(command.RequestId);
+
+        var userId = UserId.Create(command.UserId);
+
+        var updatedInfo = VolunteerInfo.Create(command.UpdatedInfo).Value;
+
+        var request = await _volunteerRequestsRepository
+            .GetByIdAsync(requestId, cancellationToken);
+
+        if (request.IsFailure)
+            return Errors.General.ValueNotFound($"VolunteerRequest with Id = {requestId.Value}").ToErrorList();
+
+        if (request.Value.UserId != userId)
+            return Errors.General
+                .Conflict($"User with id = {userId.Value} cannot amend request with id = {requestId.Value}")
+                .ToErrorList();
+
+        var result = request.Value.SetSubmitted(updatedInfo);
+        if (result.IsFailure)
+            return result.Error.ToErrorList();
+        
+        await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "User with ID = {ID1} amended request with Id = {ID2}", userId.Value, requestId.Value);
+
+        return requestId.Value;
+    }
+}

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/AmendRequest/AmendRequestValidator.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/AmendRequest/AmendRequestValidator.cs
@@ -1,0 +1,20 @@
+using FluentValidation;
+using PetFamily.Core.Extensions;
+using PetFamily.SharedKernel.CustomErrors;
+using PetFamily.VolunteerRequests.Domain.ValueObjects;
+
+namespace PetFamily.VolunteerRequests.Application.Commands.AmendRequest;
+
+public class ReviseRequestCommandValidator : AbstractValidator<AmendRequestCommand>
+{
+    public ReviseRequestCommandValidator()
+    {
+        RuleFor(c => c.RequestId)
+            .NotEmpty().WithError(Errors.General.ValueIsRequired("RequestId"));
+        
+        RuleFor(c => c.UserId)
+            .NotEmpty().WithError(Errors.General.ValueIsRequired("UserId"));
+
+        RuleFor(c => c.UpdatedInfo).MustBeValueObject(VolunteerInfo.Create);
+    }
+}

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/ApproveRequest/ApproveRequestCommand.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/ApproveRequest/ApproveRequestCommand.cs
@@ -1,0 +1,5 @@
+using PetFamily.Core.Abstractions;
+
+namespace PetFamily.VolunteerRequests.Application.Commands.ApproveRequest;
+
+public record ApproveRequestCommand(Guid RequestId, Guid AdminId) : ICommand;

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/ApproveRequest/ApproveRequestHandler.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/ApproveRequest/ApproveRequestHandler.cs
@@ -1,0 +1,74 @@
+using CSharpFunctionalExtensions;
+using FluentValidation;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using PetFamily.Accounts.Contracts;
+using PetFamily.Accounts.Contracts.Requests;
+using PetFamily.Core.Abstractions;
+using PetFamily.Core.Extensions;
+using PetFamily.SharedKernel.CustomErrors;
+using PetFamily.SharedKernel.Structs;
+using PetFamily.SharedKernel.ValueObjects.Ids;
+using PetFamily.VolunteerRequests.Application.Abstractions;
+
+namespace PetFamily.VolunteerRequests.Application.Commands.ApproveRequest;
+
+
+public class ApproveRequestHandler : ICommandHandler<Guid, ApproveRequestCommand>
+{
+    private readonly IVolunteerRequestsRepository _volunteerRequestsRepository;
+    private readonly ILogger<ApproveRequestHandler> _logger;
+    private readonly IValidator<ApproveRequestCommand> _validator;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly ICreateVolunteerAccountContract _contract;
+
+    public ApproveRequestHandler(
+        IVolunteerRequestsRepository volunteerRequestsRepository,
+        ILogger<ApproveRequestHandler> logger,
+        IValidator<ApproveRequestCommand> validator,
+        [FromKeyedServices(UnitOfWorkSelector.VolunteerRequests)]
+        IUnitOfWork unitOfWork,
+        ICreateVolunteerAccountContract contract)
+    {
+        _volunteerRequestsRepository = volunteerRequestsRepository;
+        _logger = logger;
+        _validator = validator;
+        _unitOfWork = unitOfWork;
+        _contract = contract;
+    }
+
+    public async Task<Result<Guid, ErrorList>> HandleAsync(
+        ApproveRequestCommand command,
+        CancellationToken cancellationToken)
+    {
+        var validationResult = await _validator.ValidateAsync(command, cancellationToken);
+        if (validationResult.IsValid == false)
+            return validationResult.ToErrorList();
+
+        var requestId = VolunteerRequestId.Create(command.RequestId);
+
+        var adminId = AdminId.Create(command.AdminId);
+        
+        var request = await _volunteerRequestsRepository
+            .GetByIdAsync(requestId, cancellationToken);
+
+        if (request.IsFailure)
+            return Errors.General.ValueNotFound($"VolunteerRequest with Id = {requestId.Value}").ToErrorList();
+        
+        var result = request.Value.SetApproved(adminId);
+        if (result.IsFailure)
+            return result.Error.ToErrorList();
+
+        var createVolunteerAccountRequest = new CreateVolunteerAccountRequest(request.Value.UserId);
+        var accountResult = await _contract.CreateVolunteerAccountAsync(createVolunteerAccountRequest, cancellationToken);
+        if (accountResult.IsFailure)
+            return accountResult.Error.ToErrorList();
+        
+        await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "Admin with ID = {ID1} gave volunteer role to user with id = {ID2}", adminId.Value, request.Value.UserId);
+
+        return requestId.Value;
+    }
+}

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/ApproveRequest/ApproveRequestValidator.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/ApproveRequest/ApproveRequestValidator.cs
@@ -1,0 +1,17 @@
+using FluentValidation;
+using PetFamily.Core.Extensions;
+using PetFamily.SharedKernel.CustomErrors;
+
+namespace PetFamily.VolunteerRequests.Application.Commands.ApproveRequest;
+
+public class ApproveRequestCommandValidator : AbstractValidator<ApproveRequestCommand>
+{
+    public ApproveRequestCommandValidator()
+    {
+        RuleFor(c => c.RequestId)
+            .NotEmpty().WithError(Errors.General.ValueIsRequired("RequestId"));
+        
+        RuleFor(c => c.AdminId)
+            .NotEmpty().WithError(Errors.General.ValueIsRequired("AdminId"));
+    }
+}

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/CreateVolunteerRequest/CreateVolunteerRequestCommand.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/CreateVolunteerRequest/CreateVolunteerRequestCommand.cs
@@ -1,0 +1,5 @@
+using PetFamily.Core.Abstractions;
+
+namespace PetFamily.VolunteerRequests.Application.Commands.CreateVolunteerRequest;
+
+public record CreateVolunteerRequestCommand(Guid UserId, string VolunteerInfo) : ICommand;

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/CreateVolunteerRequest/CreateVolunteerRequestHandler.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/CreateVolunteerRequest/CreateVolunteerRequestHandler.cs
@@ -1,0 +1,65 @@
+using CSharpFunctionalExtensions;
+using FluentValidation;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using PetFamily.Core.Abstractions;
+using PetFamily.Core.Extensions;
+using PetFamily.SharedKernel.CustomErrors;
+using PetFamily.SharedKernel.Structs;
+using PetFamily.SharedKernel.ValueObjects.Ids;
+using PetFamily.VolunteerRequests.Application.Abstractions;
+using PetFamily.VolunteerRequests.Domain.Entities;
+using PetFamily.VolunteerRequests.Domain.ValueObjects;
+
+namespace PetFamily.VolunteerRequests.Application.Commands.CreateVolunteerRequest;
+
+
+
+public class CreateVolunteerRequestHandler : ICommandHandler<Guid, CreateVolunteerRequestCommand>
+{
+    private readonly IVolunteerRequestsRepository _volunteerRequestsRepository;
+    private readonly ILogger<CreateVolunteerRequestHandler> _logger;
+    private readonly IValidator<CreateVolunteerRequestCommand> _validator;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public CreateVolunteerRequestHandler(
+        IVolunteerRequestsRepository volunteerRequestsRepository,
+        ILogger<CreateVolunteerRequestHandler> logger,
+        IValidator<CreateVolunteerRequestCommand> validator,
+        [FromKeyedServices(UnitOfWorkSelector.VolunteerRequests)] IUnitOfWork unitOfWork)
+    {
+        _volunteerRequestsRepository = volunteerRequestsRepository;
+        _logger = logger;
+        _validator = validator;
+        _unitOfWork = unitOfWork;
+    }
+
+    public async Task<Result<Guid, ErrorList>> HandleAsync(
+        CreateVolunteerRequestCommand command,
+        CancellationToken cancellationToken)
+    {
+        var validationResult = await _validator.ValidateAsync(command, cancellationToken);
+        if (validationResult.IsValid == false)
+            return validationResult.ToErrorList();
+        
+        var userId = UserId.Create(command.UserId);
+        
+        var existedRequest = await _volunteerRequestsRepository
+            .GetByUserIdAsync(userId, cancellationToken);
+        
+        if (existedRequest.IsSuccess)
+            return Errors.General.AlreadyExist($"Volunteer request for user with Id = {userId.Value}").ToErrorList();
+
+        var volunteerInfo = VolunteerInfo.Create(command.VolunteerInfo).Value;
+        
+        var volunteerRequest = new VolunteerRequest(userId, volunteerInfo);
+        
+        await _volunteerRequestsRepository.AddAsync(volunteerRequest, cancellationToken);
+        await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "Created VolunteerRequest with ID = {id}", volunteerRequest.Id.Value);
+        
+        return volunteerRequest.Id.Value;
+    }
+}

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/CreateVolunteerRequest/CreateVolunteerRequestHandler.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/CreateVolunteerRequest/CreateVolunteerRequestHandler.cs
@@ -13,20 +13,20 @@ using PetFamily.VolunteerRequests.Domain.ValueObjects;
 
 namespace PetFamily.VolunteerRequests.Application.Commands.CreateVolunteerRequest;
 
-
-
 public class CreateVolunteerRequestHandler : ICommandHandler<Guid, CreateVolunteerRequestCommand>
 {
     private readonly IVolunteerRequestsRepository _volunteerRequestsRepository;
     private readonly ILogger<CreateVolunteerRequestHandler> _logger;
     private readonly IValidator<CreateVolunteerRequestCommand> _validator;
     private readonly IUnitOfWork _unitOfWork;
+    private readonly int BAN_DURATION_IN_DAYS = 7;
 
     public CreateVolunteerRequestHandler(
         IVolunteerRequestsRepository volunteerRequestsRepository,
         ILogger<CreateVolunteerRequestHandler> logger,
         IValidator<CreateVolunteerRequestCommand> validator,
-        [FromKeyedServices(UnitOfWorkSelector.VolunteerRequests)] IUnitOfWork unitOfWork)
+        [FromKeyedServices(UnitOfWorkSelector.VolunteerRequests)]
+        IUnitOfWork unitOfWork)
     {
         _volunteerRequestsRepository = volunteerRequestsRepository;
         _logger = logger;
@@ -41,25 +41,48 @@ public class CreateVolunteerRequestHandler : ICommandHandler<Guid, CreateVolunte
         var validationResult = await _validator.ValidateAsync(command, cancellationToken);
         if (validationResult.IsValid == false)
             return validationResult.ToErrorList();
-        
+
         var userId = UserId.Create(command.UserId);
-        
+
         var existedRequest = await _volunteerRequestsRepository
             .GetByUserIdAsync(userId, cancellationToken);
-        
+
         if (existedRequest.IsSuccess)
-            return Errors.General.AlreadyExist($"Volunteer request for user with Id = {userId.Value}").ToErrorList();
+        {
+           var handleResult = await HandleExistedRequest(existedRequest.Value, cancellationToken);
+           if (handleResult.IsFailure)
+               return handleResult.Error.ToErrorList();
+        }
 
         var volunteerInfo = VolunteerInfo.Create(command.VolunteerInfo).Value;
-        
+
         var volunteerRequest = new VolunteerRequest(userId, volunteerInfo);
-        
+
         await _volunteerRequestsRepository.AddAsync(volunteerRequest, cancellationToken);
         await _unitOfWork.SaveChangesAsync(cancellationToken);
 
         _logger.LogInformation(
             "Created VolunteerRequest with ID = {id}", volunteerRequest.Id.Value);
-        
+
         return volunteerRequest.Id.Value;
     }
+
+    private async Task<UnitResult<Error>> HandleExistedRequest(
+        VolunteerRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (request.Status.Value != VolunteerRequestStatusEnum.Rejected)
+            return Errors.General.AlreadyExist($"Volunteer request for user with Id = {request.UserId.Value}");
+
+        
+        if (DateTime.UtcNow <= request.RejectedAt!.Value.AddDays(BAN_DURATION_IN_DAYS))
+            return Errors.General
+                .Conflict($"user with ID = {request.UserId.Value} is not allowed to create requests yet");
+        
+        _volunteerRequestsRepository.Delete(request, cancellationToken);
+        await _unitOfWork.SaveChangesAsync(cancellationToken);
+        
+        return UnitResult.Success<Error>();
+    }
+    
 }

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/CreateVolunteerRequest/CreateVolunteerRequestValidator.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/CreateVolunteerRequest/CreateVolunteerRequestValidator.cs
@@ -1,0 +1,15 @@
+using FluentValidation;
+using PetFamily.Core.Extensions;
+using PetFamily.SharedKernel.ValueObjects;
+using PetFamily.VolunteerRequests.Domain.ValueObjects;
+
+namespace PetFamily.VolunteerRequests.Application.Commands.CreateVolunteerRequest;
+
+
+public class CreateVolunteerRequestCommandValidator : AbstractValidator<CreateVolunteerRequestCommand>
+{
+    public CreateVolunteerRequestCommandValidator()
+    {
+        RuleFor(c => c.VolunteerInfo).MustBeValueObject(VolunteerInfo.Create);
+    }
+}

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/RejectRequest/RejectRequestCommand.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/RejectRequest/RejectRequestCommand.cs
@@ -1,0 +1,5 @@
+using PetFamily.Core.Abstractions;
+
+namespace PetFamily.VolunteerRequests.Application.Commands.RejectRequest;
+
+public record RejectRequestCommand(Guid RequestId, Guid AdminId) : ICommand;

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/RejectRequest/RejectRequestHandler.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/RejectRequest/RejectRequestHandler.cs
@@ -1,0 +1,64 @@
+using CSharpFunctionalExtensions;
+using FluentValidation;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using PetFamily.Core.Abstractions;
+using PetFamily.Core.Extensions;
+using PetFamily.SharedKernel.CustomErrors;
+using PetFamily.SharedKernel.Structs;
+using PetFamily.SharedKernel.ValueObjects.Ids;
+using PetFamily.VolunteerRequests.Application.Abstractions;
+using PetFamily.VolunteerRequests.Domain.ValueObjects;
+
+namespace PetFamily.VolunteerRequests.Application.Commands.RejectRequest;
+
+public class RejectRequestHandler : ICommandHandler<Guid, RejectRequestCommand>
+{
+    private readonly IVolunteerRequestsRepository _volunteerRequestsRepository;
+    private readonly ILogger<RejectRequestHandler> _logger;
+    private readonly IValidator<RejectRequestCommand> _validator;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public RejectRequestHandler(
+        IVolunteerRequestsRepository volunteerRequestsRepository,
+        ILogger<RejectRequestHandler> logger,
+        IValidator<RejectRequestCommand> validator,
+        [FromKeyedServices(UnitOfWorkSelector.VolunteerRequests)]
+        IUnitOfWork unitOfWork)
+    {
+        _volunteerRequestsRepository = volunteerRequestsRepository;
+        _logger = logger;
+        _validator = validator;
+        _unitOfWork = unitOfWork;
+    }
+
+    public async Task<Result<Guid, ErrorList>> HandleAsync(
+        RejectRequestCommand command,
+        CancellationToken cancellationToken)
+    {
+        var validationResult = await _validator.ValidateAsync(command, cancellationToken);
+        if (validationResult.IsValid == false)
+            return validationResult.ToErrorList();
+
+        var requestId = VolunteerRequestId.Create(command.RequestId);
+
+        var adminId = AdminId.Create(command.AdminId);
+        
+        var request = await _volunteerRequestsRepository
+            .GetByIdAsync(requestId, cancellationToken);
+
+        if (request.IsFailure)
+            return Errors.General.ValueNotFound($"VolunteerRequest with Id = {requestId.Value}").ToErrorList();
+
+        var result = request.Value.SetRejected(adminId);
+        if (result.IsFailure)
+            return result.Error.ToErrorList();
+        
+        await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "Admin with ID = {ID1} rejected request with ID = {ID2}", adminId.Value, requestId.Value);
+
+        return requestId.Value;
+    }
+}

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/RejectRequest/RejectRequestValidator.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/RejectRequest/RejectRequestValidator.cs
@@ -1,0 +1,17 @@
+using FluentValidation;
+using PetFamily.Core.Extensions;
+using PetFamily.SharedKernel.CustomErrors;
+
+namespace PetFamily.VolunteerRequests.Application.Commands.RejectRequest;
+
+public class RejectRequestCommandValidator : AbstractValidator<RejectRequestCommand>
+{
+    public RejectRequestCommandValidator()
+    {
+        RuleFor(c => c.RequestId)
+            .NotEmpty().WithError(Errors.General.ValueIsRequired("RequestId"));
+        
+        RuleFor(c => c.AdminId)
+            .NotEmpty().WithError(Errors.General.ValueIsRequired("AdminId"));
+    }
+}

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/RequireRevision/RequireRevisionCommand.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/RequireRevision/RequireRevisionCommand.cs
@@ -1,0 +1,5 @@
+using PetFamily.Core.Abstractions;
+
+namespace PetFamily.VolunteerRequests.Application.Commands.RequireRevision;
+
+public record RequireRevisionCommand(Guid RequestId, Guid AdminId, string RejectionComment) : ICommand;

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/RequireRevision/RequireRevisionCommand.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/RequireRevision/RequireRevisionCommand.cs
@@ -2,4 +2,4 @@ using PetFamily.Core.Abstractions;
 
 namespace PetFamily.VolunteerRequests.Application.Commands.RequireRevision;
 
-public record RequireRevisionCommand(Guid RequestId, Guid AdminId, string RejectionComment) : ICommand;
+public record RequireRevisionCommand(Guid RequestId, Guid AdminId, string RevisionComment) : ICommand;

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/RequireRevision/RequireRevisionHandler.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/RequireRevision/RequireRevisionHandler.cs
@@ -46,7 +46,7 @@ public class RequireRevisionHandler : ICommandHandler<Guid, RequireRevisionComma
 
         var adminId = AdminId.Create(command.AdminId);
         
-        var rejectionComment = RejectionComment.Create(command.RejectionComment).Value;
+        var revisionComment = RevisionComment.Create(command.RevisionComment).Value;
 
         var request = await _volunteerRequestsRepository
             .GetByIdAsync(requestId, cancellationToken);
@@ -54,7 +54,7 @@ public class RequireRevisionHandler : ICommandHandler<Guid, RequireRevisionComma
         if (request.IsFailure)
             return Errors.General.ValueNotFound($"VolunteerRequest with Id = {requestId.Value}").ToErrorList();
 
-        var result = request.Value.SetRevisionRequired(adminId, rejectionComment);
+        var result = request.Value.SetRevisionRequired(adminId, revisionComment);
         if (result.IsFailure)
             return result.Error.ToErrorList();
         

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/RequireRevision/RequireRevisionHandler.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/RequireRevision/RequireRevisionHandler.cs
@@ -1,0 +1,68 @@
+using CSharpFunctionalExtensions;
+using FluentValidation;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using PetFamily.Core.Abstractions;
+using PetFamily.Core.Extensions;
+using PetFamily.Discussions.Contracts;
+using PetFamily.Discussions.Contracts.Requests;
+using PetFamily.SharedKernel.CustomErrors;
+using PetFamily.SharedKernel.Structs;
+using PetFamily.SharedKernel.ValueObjects.Ids;
+using PetFamily.VolunteerRequests.Application.Abstractions;
+using PetFamily.VolunteerRequests.Domain.ValueObjects;
+
+namespace PetFamily.VolunteerRequests.Application.Commands.RequireRevision;
+
+public class RequireRevisionHandler : ICommandHandler<Guid, RequireRevisionCommand>
+{
+    private readonly IVolunteerRequestsRepository _volunteerRequestsRepository;
+    private readonly ILogger<RequireRevisionHandler> _logger;
+    private readonly IValidator<RequireRevisionCommand> _validator;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public RequireRevisionHandler(
+        IVolunteerRequestsRepository volunteerRequestsRepository,
+        ILogger<RequireRevisionHandler> logger,
+        IValidator<RequireRevisionCommand> validator,
+        [FromKeyedServices(UnitOfWorkSelector.VolunteerRequests)]
+        IUnitOfWork unitOfWork)
+    {
+        _volunteerRequestsRepository = volunteerRequestsRepository;
+        _logger = logger;
+        _validator = validator;
+        _unitOfWork = unitOfWork;
+    }
+
+    public async Task<Result<Guid, ErrorList>> HandleAsync(
+        RequireRevisionCommand command,
+        CancellationToken cancellationToken)
+    {
+        var validationResult = await _validator.ValidateAsync(command, cancellationToken);
+        if (validationResult.IsValid == false)
+            return validationResult.ToErrorList();
+
+        var requestId = VolunteerRequestId.Create(command.RequestId);
+
+        var adminId = AdminId.Create(command.AdminId);
+        
+        var rejectionComment = RejectionComment.Create(command.RejectionComment).Value;
+
+        var request = await _volunteerRequestsRepository
+            .GetByIdAsync(requestId, cancellationToken);
+
+        if (request.IsFailure)
+            return Errors.General.ValueNotFound($"VolunteerRequest with Id = {requestId.Value}").ToErrorList();
+
+        var result = request.Value.SetRevisionRequired(adminId, rejectionComment);
+        if (result.IsFailure)
+            return result.Error.ToErrorList();
+        
+        await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "Admin with ID = {ID1} required revision of review with Id = {ID2}", adminId.Value, requestId.Value);
+
+        return requestId.Value;
+    }
+}

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/RequireRevision/RequireRevisionValidator.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/RequireRevision/RequireRevisionValidator.cs
@@ -15,6 +15,6 @@ public class RequireRevisionCommandValidator : AbstractValidator<RequireRevision
         RuleFor(c => c.AdminId)
             .NotEmpty().WithError(Errors.General.ValueIsRequired("AdminId"));
 
-        RuleFor(c => c.RejectionComment).MustBeValueObject(RejectionComment.Create);
+        RuleFor(c => c.RevisionComment).MustBeValueObject(RevisionComment.Create);
     }
 }

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/RequireRevision/RequireRevisionValidator.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/RequireRevision/RequireRevisionValidator.cs
@@ -1,0 +1,20 @@
+using FluentValidation;
+using PetFamily.Core.Extensions;
+using PetFamily.SharedKernel.CustomErrors;
+using PetFamily.VolunteerRequests.Domain.ValueObjects;
+
+namespace PetFamily.VolunteerRequests.Application.Commands.RequireRevision;
+
+public class RequireRevisionCommandValidator : AbstractValidator<RequireRevisionCommand>
+{
+    public RequireRevisionCommandValidator()
+    {
+        RuleFor(c => c.RequestId)
+            .NotEmpty().WithError(Errors.General.ValueIsRequired("RequestId"));
+        
+        RuleFor(c => c.AdminId)
+            .NotEmpty().WithError(Errors.General.ValueIsRequired("AdminId"));
+
+        RuleFor(c => c.RejectionComment).MustBeValueObject(RejectionComment.Create);
+    }
+}

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/TakeRequestOnReview/TakeRequestOnReviewCommand.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/TakeRequestOnReview/TakeRequestOnReviewCommand.cs
@@ -1,0 +1,5 @@
+using PetFamily.Core.Abstractions;
+
+namespace PetFamily.VolunteerRequests.Application.Commands.TakeRequestOnReview;
+
+public record TakeRequestOnReviewCommand(Guid RequestId, Guid AdminId) : ICommand;

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/TakeRequestOnReview/TakeRequestOnReviewHandler.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/TakeRequestOnReview/TakeRequestOnReviewHandler.cs
@@ -58,11 +58,14 @@ public class TakeRequestOnReviewHandler : ICommandHandler<Guid, TakeRequestOnRev
         if (result.IsFailure)
             return result.Error.ToErrorList();
 
-        List<Guid> userIds = [adminId, request.Value.UserId];
-        var contractRequest = new CreateDiscussionRequest(requestId, userIds);
-        var discussion = await _contract.CreateDiscussion(contractRequest, cancellationToken);
-        if (discussion.IsFailure)
-            return discussion.Error;
+        if (request.Value.RevisionComment == null)
+        {
+            List<Guid> userIds = [adminId, request.Value.UserId];
+            var contractRequest = new CreateDiscussionRequest(requestId, userIds);
+            var discussion = await _contract.CreateDiscussion(contractRequest, cancellationToken);
+            if (discussion.IsFailure)
+                return discussion.Error;
+        }
         
         await _unitOfWork.SaveChangesAsync(cancellationToken);
 

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/TakeRequestOnReview/TakeRequestOnReviewHandler.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/TakeRequestOnReview/TakeRequestOnReviewHandler.cs
@@ -1,0 +1,74 @@
+using CSharpFunctionalExtensions;
+using FluentValidation;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using PetFamily.Core.Abstractions;
+using PetFamily.Core.Extensions;
+using PetFamily.Discussions.Contracts;
+using PetFamily.Discussions.Contracts.Requests;
+using PetFamily.SharedKernel.CustomErrors;
+using PetFamily.SharedKernel.Structs;
+using PetFamily.SharedKernel.ValueObjects.Ids;
+using PetFamily.VolunteerRequests.Application.Abstractions;
+
+namespace PetFamily.VolunteerRequests.Application.Commands.TakeRequestOnReview;
+
+public class TakeRequestOnReviewHandler : ICommandHandler<Guid, TakeRequestOnReviewCommand>
+{
+    private readonly IVolunteerRequestsRepository _volunteerRequestsRepository;
+    private readonly ILogger<TakeRequestOnReviewHandler> _logger;
+    private readonly IValidator<TakeRequestOnReviewCommand> _validator;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly ICreateDiscussionContract _contract;
+
+    public TakeRequestOnReviewHandler(
+        IVolunteerRequestsRepository volunteerRequestsRepository,
+        ILogger<TakeRequestOnReviewHandler> logger,
+        IValidator<TakeRequestOnReviewCommand> validator,
+        [FromKeyedServices(UnitOfWorkSelector.VolunteerRequests)]
+        IUnitOfWork unitOfWork,
+        ICreateDiscussionContract contract)
+    {
+        _volunteerRequestsRepository = volunteerRequestsRepository;
+        _logger = logger;
+        _validator = validator;
+        _unitOfWork = unitOfWork;
+        _contract = contract;
+    }
+
+    public async Task<Result<Guid, ErrorList>> HandleAsync(
+        TakeRequestOnReviewCommand command,
+        CancellationToken cancellationToken)
+    {
+        var validationResult = await _validator.ValidateAsync(command, cancellationToken);
+        if (validationResult.IsValid == false)
+            return validationResult.ToErrorList();
+
+        var adminId = AdminId.Create(command.AdminId);
+
+        var requestId = VolunteerRequestId.Create(command.RequestId);
+
+        var request = await _volunteerRequestsRepository
+            .GetByIdAsync(requestId, cancellationToken);
+
+        if (request.IsFailure)
+            return Errors.General.ValueNotFound($"VolunteerRequest with Id = {requestId.Value}").ToErrorList();
+
+        var result = request.Value.SetOnReview(adminId);
+        if (result.IsFailure)
+            return result.Error.ToErrorList();
+
+        List<Guid> userIds = [adminId, request.Value.UserId];
+        var contractRequest = new CreateDiscussionRequest(requestId, userIds);
+        var discussion = await _contract.CreateDiscussion(contractRequest, cancellationToken);
+        if (discussion.IsFailure)
+            return discussion.Error;
+        
+        await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "Admin with ID = {ID1} took request with {ID2} on review", adminId.Value, requestId.Value);
+
+        return requestId.Value;
+    }
+}

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/TakeRequestOnReview/TakeRequestOnReviewValidator.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/TakeRequestOnReview/TakeRequestOnReviewValidator.cs
@@ -1,0 +1,19 @@
+using FluentValidation;
+using PetFamily.Core.Extensions;
+using PetFamily.SharedKernel.CustomErrors;
+using PetFamily.VolunteerRequests.Domain.ValueObjects;
+
+namespace PetFamily.VolunteerRequests.Application.Commands.TakeRequestOnReview;
+
+
+public class TakeRequestOnReviewCommandValidator : AbstractValidator<TakeRequestOnReviewCommand>
+{
+    public TakeRequestOnReviewCommandValidator()
+    {
+        RuleFor(c => c.AdminId)
+            .NotEmpty().WithError(Errors.General.ValueIsRequired("AdminId"));
+        
+        RuleFor(c => c.RequestId)
+            .NotEmpty().WithError(Errors.General.ValueIsRequired("RequestId"));
+    }
+}

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/PetFamily.VolunteerRequests.Application.csproj
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/PetFamily.VolunteerRequests.Application.csproj
@@ -11,7 +11,6 @@
     </ItemGroup>
 
     <ItemGroup>
-      <Folder Include="Commands\" />
       <Folder Include="Queries\" />
     </ItemGroup>
 

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/PetFamily.VolunteerRequests.Application.csproj
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/PetFamily.VolunteerRequests.Application.csproj
@@ -7,6 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\..\Discussions\PetFamily.Discussions.Contracts\PetFamily.Discussions.Contracts.csproj" />
       <ProjectReference Include="..\PetFamily.VolunteerRequests.Domain\PetFamily.VolunteerRequests.Domain.csproj" />
     </ItemGroup>
 

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/PetFamily.VolunteerRequests.Application.csproj
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/PetFamily.VolunteerRequests.Application.csproj
@@ -7,6 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\..\Accounts\PetFamily.Accounts.Contracts\PetFamily.Accounts.Contracts.csproj" />
       <ProjectReference Include="..\..\Discussions\PetFamily.Discussions.Contracts\PetFamily.Discussions.Contracts.csproj" />
       <ProjectReference Include="..\PetFamily.VolunteerRequests.Domain\PetFamily.VolunteerRequests.Domain.csproj" />
     </ItemGroup>

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/PetFamily.VolunteerRequests.Application.csproj
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/PetFamily.VolunteerRequests.Application.csproj
@@ -12,8 +12,4 @@
       <ProjectReference Include="..\PetFamily.VolunteerRequests.Domain\PetFamily.VolunteerRequests.Domain.csproj" />
     </ItemGroup>
 
-    <ItemGroup>
-      <Folder Include="Queries\" />
-    </ItemGroup>
-
 </Project>

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Queries/GetHandledRequestsByAdminId/GetHandledRequestsByAdminIdHandler.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Queries/GetHandledRequestsByAdminId/GetHandledRequestsByAdminIdHandler.cs
@@ -4,7 +4,7 @@ using PetFamily.Core.Extensions;
 using PetFamily.Core.Models;
 using PetFamily.VolunteerRequests.Application.Abstractions;
 
-namespace PetFamily.VolunteerRequests.Application.Queries.GetRequestsForAdmin;
+namespace PetFamily.VolunteerRequests.Application.Queries.GetHandledRequestsByAdminId;
 
 public class GetHandledRequestsByAdminIdHandler
     : IQueryHandler<PagedList<VolunteerRequestDto>, GetHandledRequestsByAdminIdQuery>

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Queries/GetHandledRequestsByAdminId/GetHandledRequestsByAdminIdQuery.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Queries/GetHandledRequestsByAdminId/GetHandledRequestsByAdminIdQuery.cs
@@ -1,7 +1,7 @@
 using PetFamily.Core.Abstractions;
 using PetFamily.VolunteerRequests.Domain.ValueObjects;
 
-namespace PetFamily.VolunteerRequests.Application.Queries.GetRequestsForAdmin;
+namespace PetFamily.VolunteerRequests.Application.Queries.GetHandledRequestsByAdminId;
 
 public record GetHandledRequestsByAdminIdQuery : IQuery
 {

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Queries/GetRequestsByUserId/GetRequestsByUserIdHandler.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Queries/GetRequestsByUserId/GetRequestsByUserIdHandler.cs
@@ -4,7 +4,7 @@ using PetFamily.Core.Extensions;
 using PetFamily.Core.Models;
 using PetFamily.VolunteerRequests.Application.Abstractions;
 
-namespace PetFamily.VolunteerRequests.Application.Queries.GetRequestsForUser;
+namespace PetFamily.VolunteerRequests.Application.Queries.GetRequestsByUserId;
 
 public class GetRequestsByUserIdHandler
     : IQueryHandler<PagedList<VolunteerRequestDto>, GetRequestsByUserIdQuery>

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Queries/GetRequestsByUserId/GetRequestsByUserIdQuery.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Queries/GetRequestsByUserId/GetRequestsByUserIdQuery.cs
@@ -1,7 +1,6 @@
 using PetFamily.Core.Abstractions;
-using PetFamily.VolunteerRequests.Domain.ValueObjects;
 
-namespace PetFamily.VolunteerRequests.Application.Queries.GetRequestsForUser;
+namespace PetFamily.VolunteerRequests.Application.Queries.GetRequestsByUserId;
 
 public record GetRequestsByUserIdQuery : IQuery
 {

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Queries/GetRequestsForAdmin/GetHandledRequestsByAdminIdHandler.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Queries/GetRequestsForAdmin/GetHandledRequestsByAdminIdHandler.cs
@@ -20,12 +20,12 @@ public class GetHandledRequestsByAdminIdHandler
         GetHandledRequestsByAdminIdQuery query,
         CancellationToken cancellationToken)
     {
-        var volunteersQuery = _readDbContext.VolunteerRequests;
+        var volunteerRequestsQuery = _readDbContext.VolunteerRequests;
 
-        volunteersQuery = volunteersQuery.Where(v =>
+        volunteerRequestsQuery = volunteerRequestsQuery.Where(v =>
             v.AdminId == query.AdminId &&
             v.Status == query.Status);
 
-        return await volunteersQuery.ToPagedList(query.Page, query.PageSize, cancellationToken);
+        return await volunteerRequestsQuery.ToPagedList(query.Page, query.PageSize, cancellationToken);
     }
 }

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Queries/GetRequestsForAdmin/GetHandledRequestsByAdminIdHandler.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Queries/GetRequestsForAdmin/GetHandledRequestsByAdminIdHandler.cs
@@ -1,0 +1,31 @@
+using PetFamily.Core.Abstractions;
+using PetFamily.Core.Dto.VolunteerRequest;
+using PetFamily.Core.Extensions;
+using PetFamily.Core.Models;
+using PetFamily.VolunteerRequests.Application.Abstractions;
+
+namespace PetFamily.VolunteerRequests.Application.Queries.GetRequestsForAdmin;
+
+public class GetHandledRequestsByAdminIdHandler
+    : IQueryHandler<PagedList<VolunteerRequestDto>, GetHandledRequestsByAdminIdQuery>
+{
+    private readonly IReadDbContext _readDbContext;
+
+    public GetHandledRequestsByAdminIdHandler(IReadDbContext readDbContext)
+    {
+        _readDbContext = readDbContext;
+    }
+
+    public async Task<PagedList<VolunteerRequestDto>> HandleAsync(
+        GetHandledRequestsByAdminIdQuery query,
+        CancellationToken cancellationToken)
+    {
+        var volunteersQuery = _readDbContext.VolunteerRequests;
+
+        volunteersQuery = volunteersQuery.Where(v =>
+            v.AdminId == query.AdminId &&
+            v.Status == query.Status);
+
+        return await volunteersQuery.ToPagedList(query.Page, query.PageSize, cancellationToken);
+    }
+}

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Queries/GetRequestsForAdmin/GetHandledRequestsByAdminIdQuery.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Queries/GetRequestsForAdmin/GetHandledRequestsByAdminIdQuery.cs
@@ -1,0 +1,22 @@
+using PetFamily.Core.Abstractions;
+using PetFamily.VolunteerRequests.Domain.ValueObjects;
+
+namespace PetFamily.VolunteerRequests.Application.Queries.GetRequestsForAdmin;
+
+public record GetHandledRequestsByAdminIdQuery : IQuery
+{
+    public Guid AdminId { get; set; }
+    public int Page { get; set; }
+    public int PageSize { get; set; }
+    public string? Status { get; set; }
+
+    public GetHandledRequestsByAdminIdQuery(Guid adminId, int page, int pageSize, string? status = null)
+    {
+        AdminId = adminId;
+        Page = page;
+        PageSize = pageSize;
+        Status = status;
+        if (status is null)
+            Status = VolunteerRequestStatusEnum.OnReview.ToString();
+    }
+}

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Queries/GetRequestsForUser/GetRequestsByUserIdHandler.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Queries/GetRequestsForUser/GetRequestsByUserIdHandler.cs
@@ -4,26 +4,31 @@ using PetFamily.Core.Extensions;
 using PetFamily.Core.Models;
 using PetFamily.VolunteerRequests.Application.Abstractions;
 
-namespace PetFamily.VolunteerRequests.Application.Queries.GetUnhandledRequests;
+namespace PetFamily.VolunteerRequests.Application.Queries.GetRequestsForUser;
 
-public class GetUnhandledRequestsHandler 
-    : IQueryHandler<PagedList<VolunteerRequestDto>, GetUnhandledRequestsQuery>
+public class GetRequestsByUserIdHandler
+    : IQueryHandler<PagedList<VolunteerRequestDto>, GetRequestsByUserIdQuery>
 {
     private readonly IReadDbContext _readDbContext;
 
-    public GetUnhandledRequestsHandler(IReadDbContext readDbContext)
+    public GetRequestsByUserIdHandler(IReadDbContext readDbContext)
     {
         _readDbContext = readDbContext;
     }
 
     public async Task<PagedList<VolunteerRequestDto>> HandleAsync(
-        GetUnhandledRequestsQuery query,
+        GetRequestsByUserIdQuery query,
         CancellationToken cancellationToken)
     {
         var volunteerRequestsQuery = _readDbContext.VolunteerRequests;
+
+        volunteerRequestsQuery = volunteerRequestsQuery.Where(v =>
+            v.UserId == query.UserId);
         
-        volunteerRequestsQuery = volunteerRequestsQuery.Where(v => v.AdminId == null);
-        
+        volunteerRequestsQuery = volunteerRequestsQuery.WhereIf(
+            query.Status != null,
+            p => (p.Status == query.Status!));
+
         return await volunteerRequestsQuery.ToPagedList(query.Page, query.PageSize, cancellationToken);
     }
 }

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Queries/GetRequestsForUser/GetRequestsByUserIdQuery.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Queries/GetRequestsForUser/GetRequestsByUserIdQuery.cs
@@ -1,0 +1,20 @@
+using PetFamily.Core.Abstractions;
+using PetFamily.VolunteerRequests.Domain.ValueObjects;
+
+namespace PetFamily.VolunteerRequests.Application.Queries.GetRequestsForUser;
+
+public record GetRequestsByUserIdQuery : IQuery
+{
+    public Guid UserId { get; set; }
+    public int Page { get; set; }
+    public int PageSize { get; set; }
+    public string? Status { get; set; }
+
+    public GetRequestsByUserIdQuery(Guid userId, int page, int pageSize, string? status = null)
+    {
+        UserId = userId;
+        Page = page;
+        PageSize = pageSize;
+        Status = status;
+    }
+}

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Queries/GetUnhandledRequests/GetUnhandledRequestsHandler.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Queries/GetUnhandledRequests/GetUnhandledRequestsHandler.cs
@@ -1,0 +1,28 @@
+using PetFamily.Core.Abstractions;
+using PetFamily.Core.Dto.VolunteerRequest;
+using PetFamily.Core.Extensions;
+using PetFamily.Core.Models;
+using PetFamily.VolunteerRequests.Application.Abstractions;
+
+namespace PetFamily.VolunteerRequests.Application.Queries.GetUnhandledRequests;
+
+public class GetUnhandledRequestsHandler : IQueryHandler<PagedList<VolunteerRequestDto>, GetUnhandledRequestsQuery>
+{
+    private readonly IReadDbContext _readDbContext;
+
+    public GetUnhandledRequestsHandler(IReadDbContext readDbContext)
+    {
+        _readDbContext = readDbContext;
+    }
+
+    public async Task<PagedList<VolunteerRequestDto>> HandleAsync(
+        GetUnhandledRequestsQuery query,
+        CancellationToken cancellationToken)
+    {
+        var volunteersQuery = _readDbContext.VolunteerRequests;
+        
+        volunteersQuery = volunteersQuery.Where(v => v.AdminId == null);
+        
+        return await volunteersQuery.ToPagedList(query.Page, query.PageSize, cancellationToken);
+    }
+}

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Queries/GetUnhandledRequests/GetUnhandledRequestsHandler.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Queries/GetUnhandledRequests/GetUnhandledRequestsHandler.cs
@@ -1,3 +1,4 @@
+using Microsoft.EntityFrameworkCore;
 using PetFamily.Core.Abstractions;
 using PetFamily.Core.Dto.VolunteerRequest;
 using PetFamily.Core.Extensions;

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Queries/GetUnhandledRequests/GetUnhandledRequestsQuery.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Queries/GetUnhandledRequests/GetUnhandledRequestsQuery.cs
@@ -1,0 +1,5 @@
+using PetFamily.Core.Abstractions;
+
+namespace PetFamily.VolunteerRequests.Application.Queries.GetUnhandledRequests;
+
+public record GetUnhandledRequestsQuery(int Page, int PageSize) : IQuery;

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Domain/Entities/VolunteerRequest.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Domain/Entities/VolunteerRequest.cs
@@ -14,7 +14,7 @@ public class VolunteerRequest
     public VolunteerRequestStatus Status { get; private set; }
 
     public DateTime CreatedAt { get; private set; } = DateTime.UtcNow;
-    public RejectionComment? RejectionComment { get; private set; }
+    public RevisionComment? RevisionComment { get; private set; }
     
     public DateTime? RejectedAt { get; private set; }
     
@@ -57,7 +57,7 @@ public class VolunteerRequest
         return UnitResult.Success<Error>();
     }
 
-    public UnitResult<Error> SetRevisionRequired(AdminId adminId, RejectionComment rejectionComment)
+    public UnitResult<Error> SetRevisionRequired(AdminId adminId, RevisionComment revisionComment)
     {
         // RevisionRequired можно установить только тогда, когда текущий статус заявки - OnReview
         if (Status.Value != VolunteerRequestStatusEnum.OnReview)
@@ -67,7 +67,7 @@ public class VolunteerRequest
 
         AdminId = adminId;
         Status = VolunteerRequestStatus.Create(VolunteerRequestStatusEnum.RevisionRequired).Value;
-        RejectionComment = rejectionComment;
+        RevisionComment = revisionComment;
 
         return UnitResult.Success<Error>();
     }

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Domain/Entities/VolunteerRequest.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Domain/Entities/VolunteerRequest.cs
@@ -15,7 +15,9 @@ public class VolunteerRequest
 
     public DateTime CreatedAt { get; private set; } = DateTime.UtcNow;
     public RejectionComment? RejectionComment { get; private set; }
-
+    
+    public DateTime? RejectedAt { get; private set; }
+    
     private VolunteerRequest() { } // ef core
 
     public VolunteerRequest(UserId userId, VolunteerInfo volunteerInfo)
@@ -80,6 +82,7 @@ public class VolunteerRequest
 
         AdminId = adminId;
         Status = VolunteerRequestStatus.Create(VolunteerRequestStatusEnum.Rejected).Value;
+        RejectedAt = DateTime.UtcNow;
 
         return UnitResult.Success<Error>();
     }

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Domain/Entities/VolunteerRequest.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Domain/Entities/VolunteerRequest.cs
@@ -16,9 +16,7 @@ public class VolunteerRequest
     public DateTime CreatedAt { get; private set; } = DateTime.UtcNow;
     public RejectionComment? RejectionComment { get; private set; }
 
-    private VolunteerRequest()
-    {
-    } // ef core
+    private VolunteerRequest() { } // ef core
 
     public VolunteerRequest(UserId userId, VolunteerInfo volunteerInfo)
     {
@@ -28,7 +26,7 @@ public class VolunteerRequest
         VolunteerInfo = volunteerInfo;
     }
 
-    public UnitResult<Error> SetSubmitted()
+    public UnitResult<Error> SetSubmitted(VolunteerInfo volunteerInfo)
     {
         // при создании заявки (через конструктор) её статус по умолчанию всегда submitted
         // а вот установить этот статус методом можно только тогда, когда её текущий статус - RevisionRequired
@@ -38,6 +36,7 @@ public class VolunteerRequest
         }
 
         Status = VolunteerRequestStatus.Create(VolunteerRequestStatusEnum.Submitted).Value;
+        VolunteerInfo = volunteerInfo;
 
         return UnitResult.Success<Error>();
     }

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Domain/ValueObjects/RevisionComment.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Domain/ValueObjects/RevisionComment.cs
@@ -4,20 +4,20 @@ using PetFamily.SharedKernel.CustomErrors;
 
 namespace PetFamily.VolunteerRequests.Domain.ValueObjects;
 
-public record RejectionComment
+public record RevisionComment
 {
     public string Value { get; }
 
-    public RejectionComment(string value)
+    public RevisionComment(string value)
     {
         Value = value;
     }
 
-    public static Result<RejectionComment, Error> Create(string value)
+    public static Result<RevisionComment, Error> Create(string value)
     {
         if (string.IsNullOrWhiteSpace(value) || value.Length > DomainConstants.MAX_MEDIUM_TEXT_LENGTH)
             return Errors.General.ValueIsInvalid("RejectionComment");
         
-        return new RejectionComment(value);
+        return new RevisionComment(value);
     }
 }

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Infrastructure/Configurations/Read/VolunteerRequestDtoConfiguration.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Infrastructure/Configurations/Read/VolunteerRequestDtoConfiguration.cs
@@ -1,0 +1,47 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using PetFamily.Core.Dto.VolunteerRequest;
+
+namespace PetFamily.VolunteerRequests.Infrastructure.Configurations.Read;
+
+public class VolunteerRequestDtoConfiguration : IEntityTypeConfiguration<VolunteerRequestDto>
+{
+    public void Configure(EntityTypeBuilder<VolunteerRequestDto> builder)
+    {
+        builder.ToTable("volunteer_requests");
+
+        builder.HasKey(v => v.Id);
+
+        builder.Property(v => v.Id)
+            .IsRequired()
+            .HasColumnName("id");
+        
+        builder.Property(v => v.AdminId)
+            .IsRequired(false)
+            .HasColumnName("admin_id");
+
+        builder.Property(v => v.UserId)
+            .IsRequired()
+            .HasColumnName("user_id");
+
+        builder.Property(v => v.VolunteerInfo)
+            .IsRequired()
+            .HasColumnName("volunteer_info");
+        
+        builder.Property(s => s.Status)
+            .IsRequired()
+            .HasColumnName("status");
+
+        builder.Property(v => v.CreatedAt)
+            .IsRequired()
+            .HasColumnName("created_at");
+        
+        builder.Property(v => v.RejectedAt)
+            .IsRequired(false)
+            .HasColumnName("rejected_at");
+        
+        builder.Property(v => v.RevisionComment)
+            .IsRequired(false)
+            .HasColumnName("revision_comment");
+    }
+}

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Infrastructure/Configurations/Write/VolunteerRequestConfiguration.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Infrastructure/Configurations/Write/VolunteerRequestConfiguration.cs
@@ -58,11 +58,11 @@ public class VolunteerRequestConfiguration : IEntityTypeConfiguration<VolunteerR
             .IsRequired(false)
             .HasColumnName("rejected_at");
         
-        builder.Property(v => v.RejectionComment)
+        builder.Property(v => v.RevisionComment)
             .HasConversion(
-                rejectionComment => rejectionComment.Value,
-                value => RejectionComment.Create(value).Value)
+                revisionComment => revisionComment.Value,
+                value => RevisionComment.Create(value).Value)
             .IsRequired(false)
-            .HasColumnName("rejection_comment");
+            .HasColumnName("revision_comment");
     }
 }

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Infrastructure/Configurations/Write/VolunteerRequestConfiguration.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Infrastructure/Configurations/Write/VolunteerRequestConfiguration.cs
@@ -54,6 +54,10 @@ public class VolunteerRequestConfiguration : IEntityTypeConfiguration<VolunteerR
             .IsRequired()
             .HasColumnName("created_at");
         
+        builder.Property(v => v.RejectedAt)
+            .IsRequired(false)
+            .HasColumnName("rejected_at");
+        
         builder.Property(v => v.RejectionComment)
             .HasConversion(
                 rejectionComment => rejectionComment.Value,

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Infrastructure/Configurations/Write/VolunteerRequestConfiguration.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Infrastructure/Configurations/Write/VolunteerRequestConfiguration.cs
@@ -46,9 +46,7 @@ public class VolunteerRequestConfiguration : IEntityTypeConfiguration<VolunteerR
         {
             sb.Property(s => s.Value)
                 .IsRequired()
-                .HasConversion(
-                    status => (int)status,
-                    status => (VolunteerRequestStatusEnum)status)
+                .HasConversion<string>()
                 .HasColumnName("status");
         });
 

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Infrastructure/DbContexts/ReadDbContext.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Infrastructure/DbContexts/ReadDbContext.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using PetFamily.Core.Dto.VolunteerRequest;
+using PetFamily.VolunteerRequests.Application.Abstractions;
+
+namespace PetFamily.VolunteerRequests.Infrastructure.DbContexts;
+
+public class ReadDbContext: DbContext, IReadDbContext
+{
+    private readonly string _connectionString;
+    public ReadDbContext(string connectionString)
+    {
+        _connectionString = connectionString;
+    }
+
+    public IQueryable<VolunteerRequestDto> VolunteerRequests => Set<VolunteerRequestDto>();
+    
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        optionsBuilder.UseNpgsql(_connectionString);
+        optionsBuilder.UseSnakeCaseNamingConvention();
+        //optionsBuilder.UseLoggerFactory(CreateLoggerFactory());
+        optionsBuilder.UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking);
+    }
+    
+    protected override void OnModelCreating(ModelBuilder modelBuilder) 
+    {
+        //base.OnModelCreating(modelBuilder);
+        modelBuilder.ApplyConfigurationsFromAssembly(
+            typeof(ReadDbContext).Assembly,
+            type => type.FullName?.Contains("Configurations.Read") ?? false);
+        
+        modelBuilder.HasDefaultSchema("volunteer_requests");
+    }
+
+    private ILoggerFactory CreateLoggerFactory() =>
+        LoggerFactory.Create(builder => { builder.AddConsole(); });
+}

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Infrastructure/DependencyInjection.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Infrastructure/DependencyInjection.cs
@@ -30,6 +30,9 @@ public static class DependencyInjection
         services.AddScoped<WriteDbContext>(_ =>
             new WriteDbContext(configuration.GetConnectionString(InfrastructureConstants.DATABASE)!));
         
+        services.AddScoped<IReadDbContext, ReadDbContext>(_ =>
+            new ReadDbContext(configuration.GetConnectionString(InfrastructureConstants.DATABASE)!));
+        
         return services;
     }
     

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Infrastructure/PetFamily.VolunteerRequests.Infrastructure.csproj
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Infrastructure/PetFamily.VolunteerRequests.Infrastructure.csproj
@@ -16,8 +16,4 @@
       <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.8" />
     </ItemGroup>
 
-    <ItemGroup>
-      <Folder Include="Configurations\Read\" />
-    </ItemGroup>
-
 </Project>

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Infrastructure/Repositories/VolunteerRequestsRepository.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Infrastructure/Repositories/VolunteerRequestsRepository.cs
@@ -49,15 +49,12 @@ public class VolunteerRequestsRepository : IVolunteerRequestsRepository
         return volunteerRequest;
     }
 
-    public async Task<Result<VolunteerRequest, Error>> GetByUserIdAsync(
+    public async Task<List<VolunteerRequest>> GetRequestsByUserIdAsync(
         UserId userId,
         CancellationToken cancellationToken = default)
     {
         var volunteerRequest = await _context.VolunteerRequests
-            .FirstOrDefaultAsync(v => v.UserId == userId, cancellationToken);
-
-        if (volunteerRequest == null)
-            return Errors.General.ValueNotFound();
+            .Where(v => v.UserId == userId).ToListAsync(cancellationToken);
 
         return volunteerRequest;
     }

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Infrastructure/Repositories/VolunteerRequestsRepository.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Infrastructure/Repositories/VolunteerRequestsRepository.cs
@@ -36,11 +36,25 @@ public class VolunteerRequestsRepository : IVolunteerRequestsRepository
         return volunteerRequest.Id.Value;
     }
 
-    public async Task<Result<VolunteerRequest, Error>> GetByIdAsync(VolunteerRequestId id,
+    public async Task<Result<VolunteerRequest, Error>> GetByIdAsync(
+        VolunteerRequestId id,
         CancellationToken cancellationToken = default)
     {
         var volunteerRequest = await _context.VolunteerRequests
             .FirstOrDefaultAsync(v => v.Id == id, cancellationToken);
+
+        if (volunteerRequest == null)
+            return Errors.General.ValueNotFound();
+
+        return volunteerRequest;
+    }
+
+    public async Task<Result<VolunteerRequest, Error>> GetByUserIdAsync(
+        UserId userId,
+        CancellationToken cancellationToken = default)
+    {
+        var volunteerRequest = await _context.VolunteerRequests
+            .FirstOrDefaultAsync(v => v.UserId == userId, cancellationToken);
 
         if (volunteerRequest == null)
             return Errors.General.ValueNotFound();

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Presentation/PetFamily.VolunteerRequests.Presentation.csproj
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Presentation/PetFamily.VolunteerRequests.Presentation.csproj
@@ -14,7 +14,6 @@
 
     <ItemGroup>
       <Folder Include="Contracts\" />
-      <Folder Include="VolunteerRequests\Requests\" />
     </ItemGroup>
 
 </Project>

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Presentation/VolunteerRequests/Requests/AmendRequestRequest.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Presentation/VolunteerRequests/Requests/AmendRequestRequest.cs
@@ -1,0 +1,8 @@
+using PetFamily.VolunteerRequests.Application.Commands.AmendRequest;
+
+namespace PetFamily.VolunteerRequests.Presentation.VolunteerRequests.Requests;
+
+public record AmendRequestRequest(string UpdatedInfo)
+{
+    public AmendRequestCommand ToCommand(Guid requestId, Guid userId) => new (requestId, userId, UpdatedInfo);
+}

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Presentation/VolunteerRequests/Requests/CreateVolunteerRequestRequest.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Presentation/VolunteerRequests/Requests/CreateVolunteerRequestRequest.cs
@@ -1,0 +1,3 @@
+namespace PetFamily.VolunteerRequests.Presentation.VolunteerRequests.Requests;
+
+public record CreateVolunteerRequestRequest(string VolunteerInfo);

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Presentation/VolunteerRequests/Requests/GetHandledRequestsByAdminIdRequest.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Presentation/VolunteerRequests/Requests/GetHandledRequestsByAdminIdRequest.cs
@@ -1,4 +1,4 @@
-using PetFamily.VolunteerRequests.Application.Queries.GetRequestsForAdmin;
+using PetFamily.VolunteerRequests.Application.Queries.GetHandledRequestsByAdminId;
 
 namespace PetFamily.VolunteerRequests.Presentation.VolunteerRequests.Requests;
 

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Presentation/VolunteerRequests/Requests/GetHandledRequestsByAdminIdRequest.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Presentation/VolunteerRequests/Requests/GetHandledRequestsByAdminIdRequest.cs
@@ -1,0 +1,8 @@
+using PetFamily.VolunteerRequests.Application.Queries.GetRequestsForAdmin;
+
+namespace PetFamily.VolunteerRequests.Presentation.VolunteerRequests.Requests;
+
+public record GetHandledRequestsByAdminIdRequest(int Page, int PageSize, string? Status = null)
+{
+    public GetHandledRequestsByAdminIdQuery ToQuery(Guid adminId) => new(adminId, Page, PageSize, Status);
+}

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Presentation/VolunteerRequests/Requests/GetRequestsByUserIdRequest.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Presentation/VolunteerRequests/Requests/GetRequestsByUserIdRequest.cs
@@ -1,0 +1,8 @@
+using PetFamily.VolunteerRequests.Application.Queries.GetRequestsForUser;
+
+namespace PetFamily.VolunteerRequests.Presentation.VolunteerRequests.Requests;
+
+public record GetRequestsByUserIdRequest(int Page, int PageSize, string? Status = null)
+{
+    public GetRequestsByUserIdQuery ToQuery(Guid userId) => new(userId, Page, PageSize, Status);
+}

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Presentation/VolunteerRequests/Requests/GetRequestsByUserIdRequest.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Presentation/VolunteerRequests/Requests/GetRequestsByUserIdRequest.cs
@@ -1,4 +1,4 @@
-using PetFamily.VolunteerRequests.Application.Queries.GetRequestsForUser;
+using PetFamily.VolunteerRequests.Application.Queries.GetRequestsByUserId;
 
 namespace PetFamily.VolunteerRequests.Presentation.VolunteerRequests.Requests;
 

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Presentation/VolunteerRequests/Requests/GetUnhandledRequestsRequest.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Presentation/VolunteerRequests/Requests/GetUnhandledRequestsRequest.cs
@@ -1,0 +1,8 @@
+using PetFamily.VolunteerRequests.Application.Queries.GetUnhandledRequests;
+
+namespace PetFamily.VolunteerRequests.Presentation.VolunteerRequests.Requests;
+
+public record GetUnhandledRequestsRequest(int Page, int PageSize)
+{
+    public GetUnhandledRequestsQuery ToQuery() => new (Page, PageSize);
+}

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Presentation/VolunteerRequests/Requests/RequireRevisionRequest.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Presentation/VolunteerRequests/Requests/RequireRevisionRequest.cs
@@ -2,7 +2,7 @@ using PetFamily.VolunteerRequests.Application.Commands.RequireRevision;
 
 namespace PetFamily.VolunteerRequests.Presentation.VolunteerRequests.Requests;
 
-public record RequireRevisionRequest(string RejectionComment)
+public record RequireRevisionRequest(string RevisionComment)
 {
-    public RequireRevisionCommand ToCommand(Guid requestId, Guid adminId) => new(requestId, adminId, RejectionComment);
+    public RequireRevisionCommand ToCommand(Guid requestId, Guid adminId) => new(requestId, adminId, RevisionComment);
 }

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Presentation/VolunteerRequests/Requests/RequireRevisionRequest.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Presentation/VolunteerRequests/Requests/RequireRevisionRequest.cs
@@ -1,0 +1,8 @@
+using PetFamily.VolunteerRequests.Application.Commands.RequireRevision;
+
+namespace PetFamily.VolunteerRequests.Presentation.VolunteerRequests.Requests;
+
+public record RequireRevisionRequest(string RejectionComment)
+{
+    public RequireRevisionCommand ToCommand(Guid requestId, Guid adminId) => new(requestId, adminId, RejectionComment);
+}

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Presentation/VolunteerRequests/VolunteerRequestsController.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Presentation/VolunteerRequests/VolunteerRequestsController.cs
@@ -3,6 +3,7 @@ using PetFamily.Framework;
 using PetFamily.Framework.Authorization;
 using PetFamily.SharedKernel.Constants;
 using PetFamily.VolunteerRequests.Application.Commands.CreateVolunteerRequest;
+using PetFamily.VolunteerRequests.Application.Commands.RequireRevision;
 using PetFamily.VolunteerRequests.Application.Commands.TakeRequestOnReview;
 using PetFamily.VolunteerRequests.Presentation.VolunteerRequests.Requests;
 
@@ -28,13 +29,26 @@ public class VolunteerRequestsController : ApplicationController
     }
 
     [Permission("volunteerRequests.TakeRequestOnReview")]
-    [HttpPost("{id:guid}")]
+    [HttpPut("{id:guid}/set-on-review")]
     public async Task<ActionResult<Guid>> TakeRequestOnReview(
         [FromRoute] Guid id,
         [FromServices] TakeRequestOnReviewHandler handler,
         CancellationToken cancellationToken)
     {
         var command = new TakeRequestOnReviewCommand(id, GetUserId().Value);
+        var result = await handler.HandleAsync(command, cancellationToken);
+        return result.IsFailure ? result.Error.ToResponse() : result.ToResponse();
+    }
+    
+    [Permission("volunteerRequests.RequireRevision")]
+    [HttpPut("{id:guid}/require-revision")]
+    public async Task<ActionResult<Guid>> RequireRevision(
+        [FromRoute] Guid id,
+        [FromBody] RequireRevisionRequest request,
+        [FromServices] RequireRevisionHandler handler,
+        CancellationToken cancellationToken)
+    {
+        var command = request.ToCommand(id, GetUserId().Value);
         var result = await handler.HandleAsync(command, cancellationToken);
         return result.IsFailure ? result.Error.ToResponse() : result.ToResponse();
     }

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Presentation/VolunteerRequests/VolunteerRequestsController.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Presentation/VolunteerRequests/VolunteerRequestsController.cs
@@ -3,6 +3,7 @@ using PetFamily.Framework;
 using PetFamily.Framework.Authorization;
 using PetFamily.SharedKernel.Constants;
 using PetFamily.VolunteerRequests.Application.Commands.CreateVolunteerRequest;
+using PetFamily.VolunteerRequests.Application.Commands.TakeRequestOnReview;
 using PetFamily.VolunteerRequests.Presentation.VolunteerRequests.Requests;
 
 namespace PetFamily.VolunteerRequests.Presentation.VolunteerRequests;
@@ -20,8 +21,20 @@ public class VolunteerRequestsController : ApplicationController
         var onlyParticipant = CheckExclusiveRole(DomainConstants.PARTICIPANT);
         if (onlyParticipant.IsFailure)
             return onlyParticipant.Error.ToResponse();
-        
+
         var command = new CreateVolunteerRequestCommand(GetUserId().Value, request.VolunteerInfo);
+        var result = await handler.HandleAsync(command, cancellationToken);
+        return result.IsFailure ? result.Error.ToResponse() : result.ToResponse();
+    }
+
+    [Permission("volunteerRequests.TakeRequestOnReview")]
+    [HttpPost("{id:guid}")]
+    public async Task<ActionResult<Guid>> TakeRequestOnReview(
+        [FromRoute] Guid id,
+        [FromServices] TakeRequestOnReviewHandler handler,
+        CancellationToken cancellationToken)
+    {
+        var command = new TakeRequestOnReviewCommand(id, GetUserId().Value);
         var result = await handler.HandleAsync(command, cancellationToken);
         return result.IsFailure ? result.Error.ToResponse() : result.ToResponse();
     }

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Presentation/VolunteerRequests/VolunteerRequestsController.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Presentation/VolunteerRequests/VolunteerRequestsController.cs
@@ -5,6 +5,7 @@ using PetFamily.SharedKernel.Constants;
 using PetFamily.VolunteerRequests.Application.Commands.AmendRequest;
 using PetFamily.VolunteerRequests.Application.Commands.ApproveRequest;
 using PetFamily.VolunteerRequests.Application.Commands.CreateVolunteerRequest;
+using PetFamily.VolunteerRequests.Application.Commands.RejectRequest;
 using PetFamily.VolunteerRequests.Application.Commands.RequireRevision;
 using PetFamily.VolunteerRequests.Application.Commands.TakeRequestOnReview;
 using PetFamily.VolunteerRequests.Presentation.VolunteerRequests.Requests;
@@ -76,6 +77,18 @@ public class VolunteerRequestsController : ApplicationController
         CancellationToken cancellationToken)
     {
         var command = new ApproveRequestCommand(id, GetUserId().Value);
+        var result = await handler.HandleAsync(command, cancellationToken);
+        return result.IsFailure ? result.Error.ToResponse() : result.ToResponse();
+    }
+    
+    [Permission("volunteerRequests.RejectRequest")]
+    [HttpPut("{id:guid}/reject-request")]
+    public async Task<ActionResult<Guid>> RejectRequest(
+        [FromRoute] Guid id,
+        [FromServices] RejectRequestHandler handler,
+        CancellationToken cancellationToken)
+    {
+        var command = new RejectRequestCommand(id, GetUserId().Value);
         var result = await handler.HandleAsync(command, cancellationToken);
         return result.IsFailure ? result.Error.ToResponse() : result.ToResponse();
     }

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Presentation/VolunteerRequests/VolunteerRequestsController.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Presentation/VolunteerRequests/VolunteerRequestsController.cs
@@ -8,6 +8,7 @@ using PetFamily.VolunteerRequests.Application.Commands.CreateVolunteerRequest;
 using PetFamily.VolunteerRequests.Application.Commands.RejectRequest;
 using PetFamily.VolunteerRequests.Application.Commands.RequireRevision;
 using PetFamily.VolunteerRequests.Application.Commands.TakeRequestOnReview;
+using PetFamily.VolunteerRequests.Application.Queries.GetUnhandledRequests;
 using PetFamily.VolunteerRequests.Presentation.VolunteerRequests.Requests;
 
 namespace PetFamily.VolunteerRequests.Presentation.VolunteerRequests;
@@ -42,7 +43,7 @@ public class VolunteerRequestsController : ApplicationController
         var result = await handler.HandleAsync(command, cancellationToken);
         return result.IsFailure ? result.Error.ToResponse() : result.ToResponse();
     }
-    
+
     [Permission("volunteerRequests.RequireRevision")]
     [HttpPut("{id:guid}/require-revision")]
     public async Task<ActionResult<Guid>> RequireRevision(
@@ -55,7 +56,7 @@ public class VolunteerRequestsController : ApplicationController
         var result = await handler.HandleAsync(command, cancellationToken);
         return result.IsFailure ? result.Error.ToResponse() : result.ToResponse();
     }
-    
+
     [Permission("volunteerRequests.AmendRequest")]
     [HttpPut("{id:guid}/amend-request")]
     public async Task<ActionResult<Guid>> AmendRequest(
@@ -68,7 +69,7 @@ public class VolunteerRequestsController : ApplicationController
         var result = await handler.HandleAsync(command, cancellationToken);
         return result.IsFailure ? result.Error.ToResponse() : result.ToResponse();
     }
-    
+
     [Permission("volunteerRequests.ApproveRequest")]
     [HttpPut("{id:guid}/approve-request")]
     public async Task<ActionResult<Guid>> ApproveRequest(
@@ -80,7 +81,7 @@ public class VolunteerRequestsController : ApplicationController
         var result = await handler.HandleAsync(command, cancellationToken);
         return result.IsFailure ? result.Error.ToResponse() : result.ToResponse();
     }
-    
+
     [Permission("volunteerRequests.RejectRequest")]
     [HttpPut("{id:guid}/reject-request")]
     public async Task<ActionResult<Guid>> RejectRequest(
@@ -91,5 +92,17 @@ public class VolunteerRequestsController : ApplicationController
         var command = new RejectRequestCommand(id, GetUserId().Value);
         var result = await handler.HandleAsync(command, cancellationToken);
         return result.IsFailure ? result.Error.ToResponse() : result.ToResponse();
+    }
+
+    [Permission("volunteerRequests.GetUnhandledRequests")]
+    [HttpGet("get-unhandled-requests")]
+    public async Task<ActionResult<Guid>> GetUnhandledRequests(
+        [FromQuery] GetUnhandledRequestsRequest request,
+        [FromServices] GetUnhandledRequestsHandler handler,
+        CancellationToken cancellationToken)
+    {
+        var query = request.ToQuery();
+        var result = await handler.HandleAsync(query, cancellationToken);
+        return Ok(result);
     }
 }

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Presentation/VolunteerRequests/VolunteerRequestsController.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Presentation/VolunteerRequests/VolunteerRequestsController.cs
@@ -9,6 +9,7 @@ using PetFamily.VolunteerRequests.Application.Commands.RejectRequest;
 using PetFamily.VolunteerRequests.Application.Commands.RequireRevision;
 using PetFamily.VolunteerRequests.Application.Commands.TakeRequestOnReview;
 using PetFamily.VolunteerRequests.Application.Queries.GetRequestsForAdmin;
+using PetFamily.VolunteerRequests.Application.Queries.GetRequestsForUser;
 using PetFamily.VolunteerRequests.Application.Queries.GetUnhandledRequests;
 using PetFamily.VolunteerRequests.Presentation.VolunteerRequests.Requests;
 
@@ -96,7 +97,7 @@ public class VolunteerRequestsController : ApplicationController
     }
 
     [Permission("volunteerRequests.GetUnhandledRequests")]
-    [HttpGet("get-unhandled-requests")]
+    [HttpGet("unhandled-requests")]
     public async Task<ActionResult<Guid>> GetUnhandledRequests(
         [FromQuery] GetUnhandledRequestsRequest request,
         [FromServices] GetUnhandledRequestsHandler handler,
@@ -106,12 +107,24 @@ public class VolunteerRequestsController : ApplicationController
         var result = await handler.HandleAsync(query, cancellationToken);
         return Ok(result);
     }
-    
-    [Permission( "volunteerRequests.GetHandledRequestsByAdminId")]
-    [HttpGet("get-handled-requests")]
+
+    [Permission("volunteerRequests.GetHandledRequestsByAdminId")]
+    [HttpGet("handled-requests")]
     public async Task<ActionResult<Guid>> GetHandledRequestsByAdminId(
         [FromQuery] GetHandledRequestsByAdminIdRequest request,
         [FromServices] GetHandledRequestsByAdminIdHandler handler,
+        CancellationToken cancellationToken)
+    {
+        var query = request.ToQuery(GetUserId().Value);
+        var result = await handler.HandleAsync(query, cancellationToken);
+        return Ok(result);
+    }
+
+    [Permission("volunteerRequests.GetRequestsByUserId")]
+    [HttpGet("requests-by-user")]
+    public async Task<ActionResult<Guid>> GetRequestsByUserId(
+        [FromQuery] GetRequestsByUserIdRequest request,
+        [FromServices] GetRequestsByUserIdHandler handler,
         CancellationToken cancellationToken)
     {
         var query = request.ToQuery(GetUserId().Value);

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Presentation/VolunteerRequests/VolunteerRequestsController.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Presentation/VolunteerRequests/VolunteerRequestsController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using PetFamily.Framework;
 using PetFamily.Framework.Authorization;
 using PetFamily.SharedKernel.Constants;
+using PetFamily.VolunteerRequests.Application.Commands.AmendRequest;
 using PetFamily.VolunteerRequests.Application.Commands.CreateVolunteerRequest;
 using PetFamily.VolunteerRequests.Application.Commands.RequireRevision;
 using PetFamily.VolunteerRequests.Application.Commands.TakeRequestOnReview;
@@ -46,6 +47,19 @@ public class VolunteerRequestsController : ApplicationController
         [FromRoute] Guid id,
         [FromBody] RequireRevisionRequest request,
         [FromServices] RequireRevisionHandler handler,
+        CancellationToken cancellationToken)
+    {
+        var command = request.ToCommand(id, GetUserId().Value);
+        var result = await handler.HandleAsync(command, cancellationToken);
+        return result.IsFailure ? result.Error.ToResponse() : result.ToResponse();
+    }
+    
+    [Permission("volunteerRequests.AmendRequest")]
+    [HttpPut("{id:guid}/amend-request")]
+    public async Task<ActionResult<Guid>> AmendRequest(
+        [FromRoute] Guid id,
+        [FromBody] AmendRequestRequest request,
+        [FromServices] AmendRequestHandler handler,
         CancellationToken cancellationToken)
     {
         var command = request.ToCommand(id, GetUserId().Value);

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Presentation/VolunteerRequests/VolunteerRequestsController.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Presentation/VolunteerRequests/VolunteerRequestsController.cs
@@ -3,6 +3,7 @@ using PetFamily.Framework;
 using PetFamily.Framework.Authorization;
 using PetFamily.SharedKernel.Constants;
 using PetFamily.VolunteerRequests.Application.Commands.AmendRequest;
+using PetFamily.VolunteerRequests.Application.Commands.ApproveRequest;
 using PetFamily.VolunteerRequests.Application.Commands.CreateVolunteerRequest;
 using PetFamily.VolunteerRequests.Application.Commands.RequireRevision;
 using PetFamily.VolunteerRequests.Application.Commands.TakeRequestOnReview;
@@ -63,6 +64,18 @@ public class VolunteerRequestsController : ApplicationController
         CancellationToken cancellationToken)
     {
         var command = request.ToCommand(id, GetUserId().Value);
+        var result = await handler.HandleAsync(command, cancellationToken);
+        return result.IsFailure ? result.Error.ToResponse() : result.ToResponse();
+    }
+    
+    [Permission("volunteerRequests.ApproveRequest")]
+    [HttpPut("{id:guid}/approve-request")]
+    public async Task<ActionResult<Guid>> ApproveRequest(
+        [FromRoute] Guid id,
+        [FromServices] ApproveRequestHandler handler,
+        CancellationToken cancellationToken)
+    {
+        var command = new ApproveRequestCommand(id, GetUserId().Value);
         var result = await handler.HandleAsync(command, cancellationToken);
         return result.IsFailure ? result.Error.ToResponse() : result.ToResponse();
     }

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Presentation/VolunteerRequests/VolunteerRequestsController.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Presentation/VolunteerRequests/VolunteerRequestsController.cs
@@ -8,6 +8,7 @@ using PetFamily.VolunteerRequests.Application.Commands.CreateVolunteerRequest;
 using PetFamily.VolunteerRequests.Application.Commands.RejectRequest;
 using PetFamily.VolunteerRequests.Application.Commands.RequireRevision;
 using PetFamily.VolunteerRequests.Application.Commands.TakeRequestOnReview;
+using PetFamily.VolunteerRequests.Application.Queries.GetRequestsForAdmin;
 using PetFamily.VolunteerRequests.Application.Queries.GetUnhandledRequests;
 using PetFamily.VolunteerRequests.Presentation.VolunteerRequests.Requests;
 
@@ -102,6 +103,18 @@ public class VolunteerRequestsController : ApplicationController
         CancellationToken cancellationToken)
     {
         var query = request.ToQuery();
+        var result = await handler.HandleAsync(query, cancellationToken);
+        return Ok(result);
+    }
+    
+    [Permission( "volunteerRequests.GetHandledRequestsByAdminId")]
+    [HttpGet("get-handled-requests")]
+    public async Task<ActionResult<Guid>> GetHandledRequestsByAdminId(
+        [FromQuery] GetHandledRequestsByAdminIdRequest request,
+        [FromServices] GetHandledRequestsByAdminIdHandler handler,
+        CancellationToken cancellationToken)
+    {
+        var query = request.ToQuery(GetUserId().Value);
         var result = await handler.HandleAsync(query, cancellationToken);
         return Ok(result);
     }

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Presentation/VolunteerRequests/VolunteerRequestsController.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Presentation/VolunteerRequests/VolunteerRequestsController.cs
@@ -8,8 +8,8 @@ using PetFamily.VolunteerRequests.Application.Commands.CreateVolunteerRequest;
 using PetFamily.VolunteerRequests.Application.Commands.RejectRequest;
 using PetFamily.VolunteerRequests.Application.Commands.RequireRevision;
 using PetFamily.VolunteerRequests.Application.Commands.TakeRequestOnReview;
-using PetFamily.VolunteerRequests.Application.Queries.GetRequestsForAdmin;
-using PetFamily.VolunteerRequests.Application.Queries.GetRequestsForUser;
+using PetFamily.VolunteerRequests.Application.Queries.GetHandledRequestsByAdminId;
+using PetFamily.VolunteerRequests.Application.Queries.GetRequestsByUserId;
 using PetFamily.VolunteerRequests.Application.Queries.GetUnhandledRequests;
 using PetFamily.VolunteerRequests.Presentation.VolunteerRequests.Requests;
 

--- a/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Presentation/VolunteerRequests/VolunteerRequestsController.cs
+++ b/PetFamily.Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Presentation/VolunteerRequests/VolunteerRequestsController.cs
@@ -1,7 +1,28 @@
+using Microsoft.AspNetCore.Mvc;
 using PetFamily.Framework;
+using PetFamily.Framework.Authorization;
+using PetFamily.SharedKernel.Constants;
+using PetFamily.VolunteerRequests.Application.Commands.CreateVolunteerRequest;
+using PetFamily.VolunteerRequests.Presentation.VolunteerRequests.Requests;
 
 namespace PetFamily.VolunteerRequests.Presentation.VolunteerRequests;
 
 public class VolunteerRequestsController : ApplicationController
 {
+    [Permission("volunteerRequests.CreateRequest")]
+    [HttpPost]
+    public async Task<ActionResult<Guid>> CreateRequest(
+        [FromBody] CreateVolunteerRequestRequest request,
+        [FromServices] CreateVolunteerRequestHandler handler,
+        CancellationToken cancellationToken)
+    {
+        // users can have multiple roles, this feature is for users that doesn't have any roles but participant role
+        var onlyParticipant = CheckExclusiveRole(DomainConstants.PARTICIPANT);
+        if (onlyParticipant.IsFailure)
+            return onlyParticipant.Error.ToResponse();
+        
+        var command = new CreateVolunteerRequestCommand(GetUserId().Value, request.VolunteerInfo);
+        var result = await handler.HandleAsync(command, cancellationToken);
+        return result.IsFailure ? result.Error.ToResponse() : result.ToResponse();
+    }
 }

--- a/PetFamily.Backend/tests/PetFamily.Domain.UnitTests/VolunteerRequestsTests.cs
+++ b/PetFamily.Backend/tests/PetFamily.Domain.UnitTests/VolunteerRequestsTests.cs
@@ -41,7 +41,7 @@ public class VolunteerRequestsTests
         var request = new VolunteerRequest(userId, volunteerInfo);
 
         // Act
-        var result = request.SetSubmitted();
+        var result = request.SetSubmitted(volunteerInfo);
 
         // Assert
         result.IsFailure.Should().BeTrue();
@@ -60,7 +60,7 @@ public class VolunteerRequestsTests
         request.SetOnReview(adminId);
 
         // Act
-        var result = request.SetSubmitted();
+        var result = request.SetSubmitted(volunteerInfo);
 
         // Assert
         result.IsFailure.Should().BeTrue();
@@ -83,7 +83,7 @@ public class VolunteerRequestsTests
         request.SetRevisionRequired(adminId, rejectionComment);
 
         // Act
-        var result = request.SetSubmitted();
+        var result = request.SetSubmitted(volunteerInfo);
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -106,7 +106,7 @@ public class VolunteerRequestsTests
         request.SetRejected(adminId);
 
         // Act
-        var result = request.SetSubmitted();
+        var result = request.SetSubmitted(volunteerInfo);
 
         // Assert
         result.IsFailure.Should().BeTrue();
@@ -126,7 +126,7 @@ public class VolunteerRequestsTests
         request.SetApproved(adminId);
 
         // Act
-        var result = request.SetSubmitted();
+        var result = request.SetSubmitted(volunteerInfo);
 
         // Assert
         result.IsFailure.Should().BeTrue();

--- a/PetFamily.Backend/tests/PetFamily.Domain.UnitTests/VolunteerRequestsTests.cs
+++ b/PetFamily.Backend/tests/PetFamily.Domain.UnitTests/VolunteerRequestsTests.cs
@@ -26,7 +26,7 @@ public class VolunteerRequestsTests
         result.Status.Value.Should().Be(VolunteerRequestStatusEnum.Submitted);
         result.CreatedAt.Should().BeBefore(DateTime.UtcNow);
         result.CreatedAt.Should().BeAfter(DateTime.UtcNow.AddHours(-1));
-        result.RejectionComment.Should().BeNull();
+        result.RevisionComment.Should().BeNull();
     }
 
     // set Submitted //////////////////////////////////////////////////////////////////
@@ -71,16 +71,16 @@ public class VolunteerRequestsTests
     {
         // Arrange
         var DEFAULT_TEXT = "default text";
-        var REJECTION_TEXT = "rejection text";
+        var REVISION_TEXT = "revision text";
         var userId = UserId.NewUserId();
         var volunteerInfo = VolunteerInfo.Create(DEFAULT_TEXT).Value;
         var request = new VolunteerRequest(userId, volunteerInfo);
-        var rejectionComment = RejectionComment.Create(REJECTION_TEXT).Value;
+        var revisionComment = RevisionComment.Create(REVISION_TEXT).Value;
         var adminId = AdminId.NewAdminId();
         
         
         request.SetOnReview(adminId);
-        request.SetRevisionRequired(adminId, rejectionComment);
+        request.SetRevisionRequired(adminId, revisionComment);
 
         // Act
         var result = request.SetSubmitted(volunteerInfo);
@@ -88,7 +88,7 @@ public class VolunteerRequestsTests
         // Assert
         result.IsSuccess.Should().BeTrue();
         request.AdminId.Should().Be(adminId);
-        request.RejectionComment.Should().Be(rejectionComment);
+        request.RevisionComment.Should().Be(revisionComment);
         request.Status.Value.Should().Be(VolunteerRequestStatusEnum.Submitted);
     }
 
@@ -158,7 +158,7 @@ public class VolunteerRequestsTests
     {
         // Arrange
         var DEFAULT_TEXT = "default text";
-        var REJECTION_TEXT = "rejection text";
+        var REVISION_TEXT = "revision text";
         var userId = UserId.NewUserId();
         var volunteerInfo = VolunteerInfo.Create(DEFAULT_TEXT).Value;
         var request = new VolunteerRequest(userId, volunteerInfo);
@@ -178,15 +178,15 @@ public class VolunteerRequestsTests
     {
         // Arrange
         var DEFAULT_TEXT = "default text";
-        var REJECTION_TEXT = "rejection text";
+        var REVISION_TEXT = "revision text";
         var userId = UserId.NewUserId();
         var volunteerInfo = VolunteerInfo.Create(DEFAULT_TEXT).Value;
         var request = new VolunteerRequest(userId, volunteerInfo);
         var adminId = AdminId.NewAdminId();
-        var rejectionComment = RejectionComment.Create(REJECTION_TEXT).Value;
+        var revisionComment = RevisionComment.Create(REVISION_TEXT).Value;
         
         request.SetOnReview(adminId);
-        request.SetRevisionRequired(adminId, rejectionComment);
+        request.SetRevisionRequired(adminId, revisionComment);
 
         // Act
         var result = request.SetOnReview(adminId);
@@ -200,7 +200,7 @@ public class VolunteerRequestsTests
     {
         // Arrange
         var DEFAULT_TEXT = "default text";
-        var REJECTION_TEXT = "rejection text";
+        var REVISION_TEXT = "revision text";
         var userId = UserId.NewUserId();
         var volunteerInfo = VolunteerInfo.Create(DEFAULT_TEXT).Value;
         var request = new VolunteerRequest(userId, volunteerInfo);
@@ -221,7 +221,7 @@ public class VolunteerRequestsTests
     {
         // Arrange
         var DEFAULT_TEXT = "default text";
-        var REJECTION_TEXT = "rejection text";
+        var REVISION_TEXT = "revision text";
         var userId = UserId.NewUserId();
         var volunteerInfo = VolunteerInfo.Create(DEFAULT_TEXT).Value;
         var request = new VolunteerRequest(userId, volunteerInfo);
@@ -244,15 +244,15 @@ public class VolunteerRequestsTests
     {
         // Arrange
         var DEFAULT_TEXT = "default text";
-        var REJECTION_TEXT = "rejection text";
+        var REVISION_TEXT = "revision text";
         var userId = UserId.NewUserId();
         var volunteerInfo = VolunteerInfo.Create(DEFAULT_TEXT).Value;
         var request = new VolunteerRequest(userId, volunteerInfo);
         var adminId = AdminId.NewAdminId();
-        var rejectionComment = RejectionComment.Create(REJECTION_TEXT).Value;
+        var revisionComment = RevisionComment.Create(REVISION_TEXT).Value;
 
         // Act
-        var result = request.SetRevisionRequired(adminId, rejectionComment);
+        var result = request.SetRevisionRequired(adminId, revisionComment);
 
         // Assert
         result.IsFailure.Should().BeTrue();
@@ -263,22 +263,22 @@ public class VolunteerRequestsTests
     {
         // Arrange
         var DEFAULT_TEXT = "default text";
-        var REJECTION_TEXT = "rejection text";
+        var REVISION_TEXT = "revision text";
         var userId = UserId.NewUserId();
         var volunteerInfo = VolunteerInfo.Create(DEFAULT_TEXT).Value;
         var request = new VolunteerRequest(userId, volunteerInfo);
         var adminId = AdminId.NewAdminId();
-        var rejectionComment = RejectionComment.Create(REJECTION_TEXT).Value;
+        var revisionComment = RevisionComment.Create(REVISION_TEXT).Value;
         
         request.SetOnReview(adminId);
         
         // Act
-        var result = request.SetRevisionRequired(adminId, rejectionComment);
+        var result = request.SetRevisionRequired(adminId, revisionComment);
 
         // Assert
         result.IsSuccess.Should().BeTrue();
         request.AdminId.Should().Be(adminId);
-        request.RejectionComment.Value.Should().Be(rejectionComment.Value);
+        request.RevisionComment.Value.Should().Be(revisionComment.Value);
         request.Status.Value.Should().Be(VolunteerRequestStatusEnum.RevisionRequired);
     }
 
@@ -287,18 +287,18 @@ public class VolunteerRequestsTests
     {
         // Arrange
         var DEFAULT_TEXT = "default text";
-        var REJECTION_TEXT = "rejection text";
+        var REVISION_TEXT = "revision text";
         var userId = UserId.NewUserId();
         var volunteerInfo = VolunteerInfo.Create(DEFAULT_TEXT).Value;
         var request = new VolunteerRequest(userId, volunteerInfo);
         var adminId = AdminId.NewAdminId();
-        var rejectionComment = RejectionComment.Create(REJECTION_TEXT).Value;
+        var revisionComment = RevisionComment.Create(REVISION_TEXT).Value;
         
         request.SetOnReview(adminId);
-        request.SetRevisionRequired(adminId, rejectionComment);
+        request.SetRevisionRequired(adminId, revisionComment);
 
         // Act
-        var result = request.SetRevisionRequired(adminId, rejectionComment);
+        var result = request.SetRevisionRequired(adminId, revisionComment);
 
         // Assert
         result.IsFailure.Should().BeTrue();
@@ -309,18 +309,18 @@ public class VolunteerRequestsTests
     {
         // Arrange
         var DEFAULT_TEXT = "default text";
-        var REJECTION_TEXT = "rejection text";
+        var REVISION_TEXT = "revision text";
         var userId = UserId.NewUserId();
         var volunteerInfo = VolunteerInfo.Create(DEFAULT_TEXT).Value;
         var request = new VolunteerRequest(userId, volunteerInfo);
         var adminId = AdminId.NewAdminId();
-        var rejectionComment = RejectionComment.Create(REJECTION_TEXT).Value;
+        var revisionComment = RevisionComment.Create(REVISION_TEXT).Value;
 
         request.SetOnReview(adminId);
         request.SetRejected(adminId);
         
         // Act
-        var result = request.SetRevisionRequired(adminId, rejectionComment);
+        var result = request.SetRevisionRequired(adminId, revisionComment);
 
         // Assert
         result.IsFailure.Should().BeTrue();
@@ -331,18 +331,18 @@ public class VolunteerRequestsTests
     {
         // Arrange
         var DEFAULT_TEXT = "default text";
-        var REJECTION_TEXT = "rejection text";
+        var REVISION_TEXT = "revision text";
         var userId = UserId.NewUserId();
         var volunteerInfo = VolunteerInfo.Create(DEFAULT_TEXT).Value;
         var request = new VolunteerRequest(userId, volunteerInfo);
         var adminId = AdminId.NewAdminId();
-        var rejectionComment = RejectionComment.Create(REJECTION_TEXT).Value;
+        var revisionComment = RevisionComment.Create(REVISION_TEXT).Value;
         
         request.SetOnReview(adminId);
         request.SetApproved(adminId);
 
         // Act
-        var result = request.SetRevisionRequired(adminId, rejectionComment);
+        var result = request.SetRevisionRequired(adminId, revisionComment);
 
         // Assert
         result.IsFailure.Should().BeTrue();
@@ -394,15 +394,15 @@ public class VolunteerRequestsTests
     {
         // Arrange
         var DEFAULT_TEXT = "default text";
-        var REJECTION_TEXT = "rejection text";
+        var REVISION_TEXT = "revision text";
         var userId = UserId.NewUserId();
         var volunteerInfo = VolunteerInfo.Create(DEFAULT_TEXT).Value;
         var request = new VolunteerRequest(userId, volunteerInfo);
         var adminId = AdminId.NewAdminId();
-        var rejectionComment = RejectionComment.Create(REJECTION_TEXT).Value;
+        var revisionComment = RevisionComment.Create(REVISION_TEXT).Value;
         
         request.SetOnReview(adminId);
-        request.SetRevisionRequired(adminId, rejectionComment);
+        request.SetRevisionRequired(adminId, revisionComment);
 
         // Act
         var result = request.SetRejected(adminId);
@@ -496,15 +496,15 @@ public class VolunteerRequestsTests
     {
         // Arrange
         var DEFAULT_TEXT = "default text";
-        var REJECTION_TEXT = "rejection text";
+        var REVISION_TEXT = "revision text";
         var userId = UserId.NewUserId();
         var volunteerInfo = VolunteerInfo.Create(DEFAULT_TEXT).Value;
         var request = new VolunteerRequest(userId, volunteerInfo);
         var adminId = AdminId.NewAdminId();
-        var rejectionComment = RejectionComment.Create(REJECTION_TEXT).Value;
+        var revisionComment = RevisionComment.Create(REVISION_TEXT).Value;
         
         request.SetOnReview(adminId);
-        request.SetRevisionRequired(adminId, rejectionComment);
+        request.SetRevisionRequired(adminId, revisionComment);
 
         // Act
         var result = request.SetApproved(adminId);

--- a/PetFamily.Backend/tests/PetFamily.IntegrationTests/General/DataGenerator.cs
+++ b/PetFamily.Backend/tests/PetFamily.IntegrationTests/General/DataGenerator.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using PetFamily.Accounts.Application.Abstractions;
 using PetFamily.Accounts.Domain.DataModels;
 using PetFamily.Discussions.Domain.Entities;
+using PetFamily.SharedKernel.Constants;
 using PetFamily.SharedKernel.ValueObjects;
 using PetFamily.SharedKernel.ValueObjects.Ids;
 using PetFamily.Species.Domain.Entities;
@@ -102,7 +103,7 @@ public static class DataGenerator
         RoleManager<Role> roleManager,
         IAccountManager accountManager = null)
     {
-        var role = await roleManager.FindByNameAsync(ParticipantAccount.PARTICIPANT);
+        var role = await roleManager.FindByNameAsync(DomainConstants.PARTICIPANT);
         var user = CreateUser(username, email, role!);
         await userManager.CreateAsync(user, password);
         
@@ -118,19 +119,19 @@ public static class DataGenerator
     {
         foreach (var role in user.Roles)
         {
-            if (role.Name == ParticipantAccount.PARTICIPANT)
+            if (role.Name == DomainConstants.PARTICIPANT)
             {
                 var participantAccount = new ParticipantAccount(user);
                 await accountManager.CreateParticipantAccount(participantAccount);
             }
             
-            if (role.Name == VolunteerAccount.VOLUNTEER)
+            if (role.Name == DomainConstants.VOLUNTEER)
             {
                 var volunteerAccount = new VolunteerAccount(user);
                 await accountManager.CreateVolunteerAccount(volunteerAccount);
             }
             
-            if (role.Name == AdminAccount.ADMIN)
+            if (role.Name == DomainConstants.ADMIN)
             {
                 var adminAccount = new AdminAccount(user);
                 await accountManager.CreateAdminAccount(adminAccount);

--- a/PetFamily.Backend/tests/PetFamily.IntegrationTests/General/DataGenerator.cs
+++ b/PetFamily.Backend/tests/PetFamily.IntegrationTests/General/DataGenerator.cs
@@ -95,6 +95,15 @@ public static class DataGenerator
         return user.Value;
     }
 
+    public static VolunteerRequest CreateVolunteerRequest(string testInfo = "test info")
+    {
+        var userId = UserId.NewUserId();
+        var volunteerInfo = VolunteerInfo.Create(testInfo).Value;
+        var request = new VolunteerRequest(userId, volunteerInfo);
+
+        return request;
+    }
+
     public static async Task<User> SeedUserAsync(
         string username,
         string email,
@@ -106,10 +115,10 @@ public static class DataGenerator
         var role = await roleManager.FindByNameAsync(DomainConstants.PARTICIPANT);
         var user = CreateUser(username, email, role!);
         await userManager.CreateAsync(user, password);
-        
+
         if (accountManager != null)
             await AddAccountsToUser(user, accountManager);
-        
+
         return user;
     }
 
@@ -124,13 +133,13 @@ public static class DataGenerator
                 var participantAccount = new ParticipantAccount(user);
                 await accountManager.CreateParticipantAccount(participantAccount);
             }
-            
+
             if (role.Name == DomainConstants.VOLUNTEER)
             {
                 var volunteerAccount = new VolunteerAccount(user);
                 await accountManager.CreateVolunteerAccount(volunteerAccount);
             }
-            
+
             if (role.Name == DomainConstants.ADMIN)
             {
                 var adminAccount = new AdminAccount(user);
@@ -244,31 +253,45 @@ public static class DataGenerator
         return volunteer;
     }
 
-    public static async Task<VolunteerRequest> SeedVolunteerRequest(VolunteerRequestsWriteDbContext dbContext)
+    public static async Task<VolunteerRequest> SeedVolunteerRequest(
+        VolunteerRequestsWriteDbContext dbContext, Guid? optionalId = null)
     {
         var DEFAULT_TEXT = "default text";
         var userId = UserId.NewUserId();
+        
+        if (optionalId.HasValue)
+            userId = optionalId.Value;
+        
         var volunteerInfo = VolunteerInfo.Create(DEFAULT_TEXT).Value;
         var request = new VolunteerRequest(userId, volunteerInfo);
-        
+
         await dbContext.VolunteerRequests.AddAsync(request);
         await dbContext.SaveChangesAsync();
-        
+
         return request;
     }
-    
+
+    public static async Task<VolunteerRequest> SeedVolunteerRequest(
+        VolunteerRequestsWriteDbContext dbContext,
+        VolunteerRequest volunteerRequest)
+    {
+        dbContext.VolunteerRequests.Add(volunteerRequest);
+        await dbContext.SaveChangesAsync();
+        return volunteerRequest;
+    }
+
     public static async Task<Discussion> SeedDiscussion(DiscussionsWriteDbContext dbContext, int userCount)
     {
         var users = new List<UserId>();
         for (var i = 0; i < userCount; i++)
             users.Add(UserId.NewUserId());
-        
+
         var relationId = RelationId.NewRelationId();
 
         var result = Discussion.Create(relationId, users);
         await dbContext.AddAsync(result.Value);
         await dbContext.SaveChangesAsync();
-        
+
         return result.Value;
     }
 }

--- a/PetFamily.Backend/tests/PetFamily.IntegrationTests/IntegrationTestsWebFactory.cs
+++ b/PetFamily.Backend/tests/PetFamily.IntegrationTests/IntegrationTestsWebFactory.cs
@@ -18,7 +18,10 @@ using SpeciesWriteDbContext = PetFamily.Species.Infrastructure.DbContexts.WriteD
 using SpeciesReadDbContext = PetFamily.Species.Infrastructure.DbContexts.ReadDbContext;
 using SpeciesIReadDbContext = PetFamily.Species.Application.IReadDbContext;
 using VolunteerRequestsWriteDbContext = PetFamily.VolunteerRequests.Infrastructure.DbContexts.WriteDbContext;
+using VolunteerRequestsReadDbContext = PetFamily.VolunteerRequests.Infrastructure.DbContexts.ReadDbContext;
+using VolunteerRequestsIReadDbContext = PetFamily.VolunteerRequests.Application.Abstractions.IReadDbContext;
 using DiscussionsWriteDbContext = PetFamily.Discussions.Infrastructure.DbContexts.WriteDbContext;
+
 
 namespace PetFamily.IntegrationTests;
 
@@ -75,12 +78,21 @@ public class IntegrationTestsWebFactory : WebApplicationFactory<Program>, IAsync
     {
         var writeDbContext = services.SingleOrDefault(s =>
             s.ServiceType == typeof(VolunteerRequestsWriteDbContext));
+        
+        var readDbContext = services.SingleOrDefault(s =>
+            s.ServiceType == typeof(VolunteerRequestsIReadDbContext));
 
         if (writeDbContext is not null)
             services.Remove(writeDbContext);
 
+        if (readDbContext is not null)
+            services.Remove(readDbContext);
+        
         services.AddScoped<VolunteerRequestsWriteDbContext>(_ =>
             new VolunteerRequestsWriteDbContext(_dbContainer.GetConnectionString()));
+        
+        services.AddScoped<VolunteerRequestsIReadDbContext, VolunteerRequestsReadDbContext>(_ =>
+            new VolunteerRequestsReadDbContext(_dbContainer.GetConnectionString()));
     }
 
     private void ReconfigureAccountsServices(IServiceCollection services)

--- a/PetFamily.Backend/tests/PetFamily.IntegrationTests/VolunteerRequests/HandlerTests/AmendRequest.cs
+++ b/PetFamily.Backend/tests/PetFamily.IntegrationTests/VolunteerRequests/HandlerTests/AmendRequest.cs
@@ -1,0 +1,55 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using PetFamily.Core.Abstractions;
+using PetFamily.IntegrationTests.General;
+using PetFamily.IntegrationTests.VolunteerRequests.Heritage;
+using PetFamily.VolunteerRequests.Application.Commands.AmendRequest;
+using PetFamily.VolunteerRequests.Domain.ValueObjects;
+
+namespace PetFamily.IntegrationTests.VolunteerRequests.HandlerTests;
+
+
+public class AmendRequest : VolunteerRequestsTestsBase
+{
+    private readonly ICommandHandler<Guid, AmendRequestCommand> _sut;
+
+    public AmendRequest(VolunteerRequestsWebFactory factory) : base(factory)
+    {
+        _sut = Scope.ServiceProvider.GetRequiredService<ICommandHandler<Guid, AmendRequestCommand>>();
+    }
+    
+    [Fact]
+    public async Task AmendRequest_success_should_set_request_status_to_submitted_and_change_request_info()
+    {
+        // arrange
+        var REVISION_TEXT = "REVISION TEXT";
+        var UPDATED_INFO = "UPDATED INFO";
+        var adminId = Guid.NewGuid();
+        var revisionComment = RevisionComment.Create(REVISION_TEXT).Value;
+        
+        var seededRequest = await DataGenerator.SeedVolunteerRequest(WriteDbContext);
+        seededRequest.SetOnReview(adminId);
+        seededRequest.SetRevisionRequired(adminId, revisionComment);
+        await WriteDbContext.SaveChangesAsync();
+        
+        var command = new AmendRequestCommand(seededRequest.Id, seededRequest.UserId, UPDATED_INFO);
+        
+        // act
+        var result = await _sut.HandleAsync(command, CancellationToken.None);
+        
+        // assert
+        result.IsSuccess.Should().BeTrue();
+        var changedRequest = await WriteDbContext.VolunteerRequests
+            .FirstOrDefaultAsync(v => v.Id == seededRequest.Id);
+        changedRequest.Should().NotBeNull();
+        changedRequest.Status.Value.Should().Be(VolunteerRequestStatusEnum.Submitted);
+        
+        // changing request by amend should change volunteer info
+        changedRequest.VolunteerInfo.Value.Should().Be(UPDATED_INFO);
+        
+        // should not lose its adminId and revision comment
+        changedRequest.RevisionComment.Value.Should().Be(REVISION_TEXT);
+        changedRequest.AdminId.Should().Be(adminId);
+    }
+}

--- a/PetFamily.Backend/tests/PetFamily.IntegrationTests/VolunteerRequests/HandlerTests/ApproveRequestTests.cs
+++ b/PetFamily.Backend/tests/PetFamily.IntegrationTests/VolunteerRequests/HandlerTests/ApproveRequestTests.cs
@@ -1,0 +1,80 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using PetFamily.Accounts.Domain.DataModels;
+using PetFamily.Core.Abstractions;
+using PetFamily.Discussions.Domain.Entities;
+using PetFamily.Discussions.Domain.ValueObjects;
+using PetFamily.IntegrationTests.General;
+using PetFamily.IntegrationTests.VolunteerRequests.Heritage;
+using PetFamily.SharedKernel.Constants;
+using PetFamily.SharedKernel.ValueObjects;
+using PetFamily.SharedKernel.ValueObjects.Ids;
+using PetFamily.VolunteerRequests.Application.Commands.ApproveRequest;
+using PetFamily.VolunteerRequests.Domain.ValueObjects;
+
+namespace PetFamily.IntegrationTests.VolunteerRequests.HandlerTests;
+
+
+public class ApproveRequestTests : VolunteerRequestsTestsBase
+{
+    private readonly ICommandHandler<Guid, ApproveRequestCommand> _sut;
+
+    public ApproveRequestTests(VolunteerRequestsWebFactory factory) : base(factory)
+    {
+        _sut = Scope.ServiceProvider.GetRequiredService<ICommandHandler<Guid, ApproveRequestCommand>>();
+    }
+    
+    [Fact]
+    public async Task ApproveRequest_success_should_set_request_status_to_Approved_and_make_user_a_volunteer()
+    {
+        // arrange
+        var adminId = Guid.NewGuid();
+        
+        var fullname = FullName.Create("FirstName", "LastName", "Surname").Value;
+        var USER_NAME = "TestUser";
+        var EMAIL = "test@test.com";
+        var role = await RoleManager.FindByNameAsync(DomainConstants.PARTICIPANT);
+        var user = User.CreateParticipant(USER_NAME, EMAIL, fullname, role).Value;
+        var creationResult = await UserManager.CreateAsync(user);
+        
+        var seededRequest = await DataGenerator.SeedVolunteerRequest(WriteDbContext, user.Id);
+        seededRequest.SetOnReview(adminId);
+        await WriteDbContext.SaveChangesAsync();
+        
+        List<UserId> UserIds = [adminId, seededRequest.UserId];
+        var discussion = Discussion.Create(seededRequest.Id.Value, UserIds).Value;
+        DiscussionsDbContext.Add(discussion);
+        await DiscussionsDbContext.SaveChangesAsync();
+        
+        var command = new ApproveRequestCommand(seededRequest.Id, adminId);
+        
+        // act
+        var result = await _sut.HandleAsync(command, CancellationToken.None);
+        
+        // assert
+        result.IsSuccess.Should().BeTrue();
+        var changedRequest = await WriteDbContext.VolunteerRequests
+            .FirstOrDefaultAsync(v => v.Id == seededRequest.Id);
+        changedRequest.Should().NotBeNull();
+        changedRequest.Status.Value.Should().Be(VolunteerRequestStatusEnum.Approved);
+        
+        // should close discussion that is related to request
+        var updatedDiscussion = await DiscussionsDbContext.Discussions
+            .FirstOrDefaultAsync(d => d.Id == discussion.Id);
+        
+        updatedDiscussion.Should().NotBeNull();
+        updatedDiscussion.Status.Value.Should().Be(DiscussionStatusEnum.Closed);
+        
+        // should make user a volunteer while not losing its participant role
+        var userRoles = await UserManager.GetRolesAsync(user);
+        userRoles.Count.Should().Be(2);
+        userRoles.Should().Contain(DomainConstants.VOLUNTEER);
+        userRoles.Should().Contain(DomainConstants.PARTICIPANT);
+        
+        // should create a volunteer account for user
+        AccountsDbContext.VolunteerAccounts
+            .FirstOrDefaultAsync(a => a.UserId == user.Id).Should().NotBeNull();
+    }
+}

--- a/PetFamily.Backend/tests/PetFamily.IntegrationTests/VolunteerRequests/HandlerTests/CreateVolunteerRequestTests.cs
+++ b/PetFamily.Backend/tests/PetFamily.IntegrationTests/VolunteerRequests/HandlerTests/CreateVolunteerRequestTests.cs
@@ -1,0 +1,191 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using PetFamily.Core.Abstractions;
+using PetFamily.IntegrationTests.General;
+using PetFamily.IntegrationTests.VolunteerRequests.Heritage;
+using PetFamily.VolunteerRequests.Application.Commands.CreateVolunteerRequest;
+using PetFamily.VolunteerRequests.Domain.Entities;
+using PetFamily.VolunteerRequests.Domain.ValueObjects;
+
+namespace PetFamily.IntegrationTests.VolunteerRequests.HandlerTests;
+
+public class CreateVolunteerRequestTests : VolunteerRequestsTestsBase
+{
+    private readonly ICommandHandler<Guid, CreateVolunteerRequestCommand> _sut;
+
+    public CreateVolunteerRequestTests(VolunteerRequestsWebFactory factory) : base(factory)
+    {
+        _sut = Scope.ServiceProvider.GetRequiredService<ICommandHandler<Guid, CreateVolunteerRequestCommand>>();
+    }
+
+    [Fact]
+    public async Task CreateVolunteerRequest_success_should_create_new_volunteerRequest()
+    {
+        // arrange
+        var request = DataGenerator.CreateVolunteerRequest();
+        
+        var command = new CreateVolunteerRequestCommand(request.UserId, request.VolunteerInfo.Value);
+        
+        // act
+        var result = await _sut.HandleAsync(command, CancellationToken.None);
+        
+        // assert
+        result.IsSuccess.Should().BeTrue();
+        WriteDbContext.VolunteerRequests.Count().Should().Be(1);
+    }
+    
+    [Fact]
+    public async Task CreateVolunteerRequest_failure_should_return_error_because_user_have_Submitted_request()
+    {
+        // arrange
+        var userId = Guid.NewGuid();
+        var VOLUNTEER_INFO = "test info";
+        
+        var seededRequest = await DataGenerator.SeedVolunteerRequest(WriteDbContext, userId);
+        
+        var command = new CreateVolunteerRequestCommand(userId, VOLUNTEER_INFO);
+        
+        // act
+        var result = await _sut.HandleAsync(command, CancellationToken.None);
+        
+        // assert
+        result.IsFailure.Should().BeTrue();
+        WriteDbContext.VolunteerRequests.Count().Should().Be(1);
+        WriteDbContext.VolunteerRequests.First().Id.Should().Be(seededRequest.Id);
+    }
+    
+    [Fact]
+    public async Task CreateVolunteerRequest_failure_should_return_error_because_user_have_OnReview_request()
+    {
+        // arrange
+        var userId = Guid.NewGuid();
+        var adminId = Guid.NewGuid();
+        var VOLUNTEER_INFO = "test info";
+        
+        var seededRequest = await DataGenerator.SeedVolunteerRequest(WriteDbContext, userId);
+        seededRequest.SetOnReview(adminId);
+        await WriteDbContext.SaveChangesAsync();
+        
+        var command = new CreateVolunteerRequestCommand(userId, VOLUNTEER_INFO);
+        
+        // act
+        var result = await _sut.HandleAsync(command, CancellationToken.None);
+        
+        // assert
+        result.IsFailure.Should().BeTrue();
+        WriteDbContext.VolunteerRequests.Count().Should().Be(1);
+        WriteDbContext.VolunteerRequests.First().Id.Should().Be(seededRequest.Id);
+    }
+    
+    [Fact]
+    public async Task CreateVolunteerRequest_failure_should_return_error_because_user_have_RevisionRequired_request()
+    {
+        // arrange
+        var userId = Guid.NewGuid();
+        var adminId = Guid.NewGuid();
+        var VOLUNTEER_INFO = "test info";
+        var REVISION_TEXT = "revision text";
+        
+        var seededRequest = await DataGenerator.SeedVolunteerRequest(WriteDbContext, userId);
+        var revisionComment = RevisionComment.Create(REVISION_TEXT).Value;
+        seededRequest.SetOnReview(adminId);
+        seededRequest.SetRevisionRequired(adminId, revisionComment);
+        await WriteDbContext.SaveChangesAsync();
+        
+        var command = new CreateVolunteerRequestCommand(userId, VOLUNTEER_INFO);
+        
+        // act
+        var result = await _sut.HandleAsync(command, CancellationToken.None);
+        
+        // assert
+        result.IsFailure.Should().BeTrue();
+        WriteDbContext.VolunteerRequests.Count().Should().Be(1);
+        WriteDbContext.VolunteerRequests.First().Id.Should().Be(seededRequest.Id);
+    }
+    
+    [Fact]
+    public async Task CreateVolunteerRequest_success_should_create_new_request_while_having_expired_rejected_request()
+    {
+        // arrange
+        var userId = Guid.NewGuid();
+        var adminId = Guid.NewGuid();
+        var VOLUNTEER_INFO = "test info";
+        const int DAYS = -10;
+        
+        var seededRequest = await DataGenerator.SeedVolunteerRequest(WriteDbContext, userId);
+        seededRequest.SetOnReview(adminId);
+        seededRequest.SetRejected(adminId);
+        var propertyInfo = typeof(VolunteerRequest).GetProperty("RejectedAt");
+        propertyInfo?.SetValue(seededRequest, DateTime.UtcNow.AddDays(DAYS));
+        await WriteDbContext.SaveChangesAsync();
+        
+        var command = new CreateVolunteerRequestCommand(userId, VOLUNTEER_INFO);
+        
+        // act
+        var result = await _sut.HandleAsync(command, CancellationToken.None);
+        
+        // assert
+        result.IsSuccess.Should().BeTrue();
+        WriteDbContext.VolunteerRequests.Count().Should().Be(2);
+        var addedRequest = await WriteDbContext.VolunteerRequests
+            .FirstOrDefaultAsync(r => r.Id == result.Value);
+        
+        addedRequest.Should().NotBeNull();
+    }
+    
+    [Fact]
+    public async Task CreateVolunteerRequest_failure_should_return_error_because_of_non_expired_rejected_request()
+    {
+        // arrange
+        var userId = Guid.NewGuid();
+        var adminId = Guid.NewGuid();
+        var VOLUNTEER_INFO = "test info";
+        const int DAYS = 10;
+        
+        var seededRequest = await DataGenerator.SeedVolunteerRequest(WriteDbContext, userId);
+        seededRequest.SetOnReview(adminId);
+        seededRequest.SetRejected(adminId);
+        await WriteDbContext.SaveChangesAsync();
+        
+        var command = new CreateVolunteerRequestCommand(userId, VOLUNTEER_INFO);
+        
+        // act
+        var result = await _sut.HandleAsync(command, CancellationToken.None);
+        
+        // assert
+        result.IsFailure.Should().BeTrue();
+        WriteDbContext.VolunteerRequests.Count().Should().Be(1); 
+        WriteDbContext.VolunteerRequests.First().Id.Should().Be(seededRequest.Id);
+    }
+    
+    // in case if user lost its volunteer role and trying to apply for being volunteer again
+    [Fact]
+    public async Task CreateVolunteerRequest_success_should_create_request_while_having_approved_request()
+    {
+        // arrange
+        var userId = Guid.NewGuid();
+        var adminId = Guid.NewGuid();
+        var VOLUNTEER_INFO = "test info";
+        const int DAYS = 10;
+        
+        var seededRequest = await DataGenerator.SeedVolunteerRequest(WriteDbContext, userId);
+        seededRequest.SetOnReview(adminId);
+        seededRequest.SetApproved(adminId);
+        await WriteDbContext.SaveChangesAsync();
+        
+        var command = new CreateVolunteerRequestCommand(userId, VOLUNTEER_INFO);
+        
+        // act
+        var result = await _sut.HandleAsync(command, CancellationToken.None);
+        
+        // assert
+        result.IsSuccess.Should().BeTrue();
+        WriteDbContext.VolunteerRequests.Count().Should().Be(2); 
+        var addedRequest = await WriteDbContext.VolunteerRequests
+            .FirstOrDefaultAsync(r => r.Id == result.Value);
+        
+        addedRequest.Should().NotBeNull();
+    }
+    
+}

--- a/PetFamily.Backend/tests/PetFamily.IntegrationTests/VolunteerRequests/HandlerTests/GetHandledRequestsByAdminIdTests.cs
+++ b/PetFamily.Backend/tests/PetFamily.IntegrationTests/VolunteerRequests/HandlerTests/GetHandledRequestsByAdminIdTests.cs
@@ -1,0 +1,101 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using PetFamily.Core.Abstractions;
+using PetFamily.Core.Dto.VolunteerRequest;
+using PetFamily.Core.Models;
+using PetFamily.IntegrationTests.General;
+using PetFamily.IntegrationTests.VolunteerRequests.Heritage;
+using PetFamily.VolunteerRequests.Application.Queries.GetHandledRequestsByAdminId;
+using PetFamily.VolunteerRequests.Domain.ValueObjects;
+
+namespace PetFamily.IntegrationTests.VolunteerRequests.HandlerTests;
+
+public class GetHandledRequestsByAdminIdTests : VolunteerRequestsTestsBase
+{
+    private readonly IQueryHandler<PagedList<VolunteerRequestDto>, GetHandledRequestsByAdminIdQuery> _sut;
+
+    public GetHandledRequestsByAdminIdTests(VolunteerRequestsWebFactory factory) : base(factory)
+    {
+        _sut = Scope.ServiceProvider
+            .GetRequiredService<IQueryHandler<PagedList<VolunteerRequestDto>, GetHandledRequestsByAdminIdQuery>>();
+    }
+    
+    [Fact]
+    public async Task GetHandledRequestsByAdminId_should_return_1_request_because_of_default_filtration()
+    {
+        // arrange
+        var PAGE = 1;
+        var PAGE_SIZE = 3;
+        
+        var adminId1 = Guid.NewGuid();
+        var adminId2 = Guid.NewGuid();
+        var seededRequest1 = await DataGenerator.SeedVolunteerRequest(WriteDbContext);
+        var seededRequest2 = await DataGenerator.SeedVolunteerRequest(WriteDbContext);
+        var seededRequest3 = await DataGenerator.SeedVolunteerRequest(WriteDbContext, seededRequest1.UserId);
+        
+        seededRequest1.SetOnReview(adminId1);
+        seededRequest1.SetApproved(adminId1);
+
+        seededRequest2.SetOnReview(adminId2);
+        seededRequest2.SetApproved(adminId2);
+
+        seededRequest3.SetOnReview(adminId1);
+        await WriteDbContext.SaveChangesAsync();
+        
+        var query = new GetHandledRequestsByAdminIdQuery(adminId1, PAGE, PAGE_SIZE);
+        
+        // act
+        var result = await _sut.HandleAsync(query, CancellationToken.None);
+        
+        // assert
+        result.TotalCount.Should().Be(1);
+        result.Items.Count().Should().Be(1);
+        result.Items.Should().NotContain(v => v.Id == seededRequest1.Id);
+        result.Items.Should().NotContain(v => v.Id == seededRequest2.Id);
+        result.Items.Should().Contain(v => v.Id == seededRequest3.Id);
+    }
+    
+    [Fact]
+    public async Task GetHandledRequestsByAdminId_should_return_only_2_requests_because_of_filtration()
+    {
+        // arrange
+        var PAGE = 1;
+        var PAGE_SIZE = 3;
+        
+        var adminId1 = Guid.NewGuid();
+        var adminId2 = Guid.NewGuid();
+        var seededRequest1 = await DataGenerator.SeedVolunteerRequest(WriteDbContext);
+        var seededRequest2 = await DataGenerator.SeedVolunteerRequest(WriteDbContext);
+        var seededRequest3 = await DataGenerator.SeedVolunteerRequest(WriteDbContext, seededRequest1.UserId);
+        var seededRequest4 = await DataGenerator.SeedVolunteerRequest(WriteDbContext);
+        
+        seededRequest1.SetOnReview(adminId1);
+        seededRequest1.SetRejected(adminId1);
+
+        seededRequest2.SetOnReview(adminId2);
+        seededRequest2.SetApproved(adminId2);
+
+        seededRequest3.SetOnReview(adminId1);
+        seededRequest3.SetRejected(adminId1);
+        
+        seededRequest4.SetOnReview(adminId1);
+        
+        await WriteDbContext.SaveChangesAsync();
+        
+        var query = new GetHandledRequestsByAdminIdQuery(
+            adminId1,
+            PAGE,
+            PAGE_SIZE,
+            VolunteerRequestStatusEnum.Rejected.ToString());
+        
+        // act
+        var result = await _sut.HandleAsync(query, CancellationToken.None);
+        
+        // assert
+        result.TotalCount.Should().Be(2);
+        result.Items.Count().Should().Be(2);
+        result.Items.Should().Contain(v => v.Id == seededRequest1.Id);
+        result.Items.Should().NotContain(v => v.Id == seededRequest2.Id);
+        result.Items.Should().Contain(v => v.Id == seededRequest3.Id);
+    }
+}

--- a/PetFamily.Backend/tests/PetFamily.IntegrationTests/VolunteerRequests/HandlerTests/GetRequestsByUserIdTests.cs
+++ b/PetFamily.Backend/tests/PetFamily.IntegrationTests/VolunteerRequests/HandlerTests/GetRequestsByUserIdTests.cs
@@ -1,0 +1,97 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using PetFamily.Core.Abstractions;
+using PetFamily.Core.Dto.VolunteerRequest;
+using PetFamily.Core.Models;
+using PetFamily.IntegrationTests.General;
+using PetFamily.IntegrationTests.VolunteerRequests.Heritage;
+using PetFamily.VolunteerRequests.Application.Queries.GetRequestsByUserId;
+using PetFamily.VolunteerRequests.Domain.ValueObjects;
+
+namespace PetFamily.IntegrationTests.VolunteerRequests.HandlerTests;
+
+public class GetRequestsByUserIdTests : VolunteerRequestsTestsBase
+{
+    private readonly IQueryHandler<PagedList<VolunteerRequestDto>, GetRequestsByUserIdQuery> _sut;
+
+    public GetRequestsByUserIdTests(VolunteerRequestsWebFactory factory) : base(factory)
+    {
+        _sut = Scope.ServiceProvider
+            .GetRequiredService<IQueryHandler<PagedList<VolunteerRequestDto>, GetRequestsByUserIdQuery>>();
+    }
+    
+    [Fact]
+    public async Task GetRequestsByUserId_should_return_3_requests()
+    {
+        // arrange
+        var PAGE = 1;
+        var PAGE_SIZE = 3;
+        
+        var adminId = Guid.NewGuid();
+        var seededRequest1 = await DataGenerator.SeedVolunteerRequest(WriteDbContext);
+        var seededRequest2 = await DataGenerator.SeedVolunteerRequest(WriteDbContext, seededRequest1.UserId);
+        var seededRequest3 = await DataGenerator.SeedVolunteerRequest(WriteDbContext, seededRequest1.UserId);
+        var seededRequest4 = await DataGenerator.SeedVolunteerRequest(WriteDbContext);
+        
+        seededRequest1.SetOnReview(adminId);
+
+        seededRequest2.SetOnReview(adminId);
+        seededRequest2.SetApproved(adminId);
+
+        seededRequest3.SetOnReview(adminId);
+        seededRequest3.SetRejected(adminId);
+        await WriteDbContext.SaveChangesAsync();
+        
+        var query = new GetRequestsByUserIdQuery(seededRequest1.UserId, PAGE, PAGE_SIZE);
+        
+        // act
+        var result = await _sut.HandleAsync(query, CancellationToken.None);
+        
+        // assert
+        result.TotalCount.Should().Be(3);
+        result.Items.Count().Should().Be(3);
+        result.Items.Should().Contain(v => v.Id == seededRequest1.Id);
+        result.Items.Should().Contain(v => v.Id == seededRequest2.Id);
+        result.Items.Should().Contain(v => v.Id == seededRequest3.Id);
+    }
+    
+    [Fact]
+    public async Task GetRequestsByUserId_should_return_2_requests_because_of_filtration()
+    {
+        // arrange
+        var PAGE = 1;
+        var PAGE_SIZE = 3;
+        
+        var adminId = Guid.NewGuid();
+        var seededRequest1 = await DataGenerator.SeedVolunteerRequest(WriteDbContext);
+        var seededRequest2 = await DataGenerator.SeedVolunteerRequest(WriteDbContext, seededRequest1.UserId);
+        var seededRequest3 = await DataGenerator.SeedVolunteerRequest(WriteDbContext, seededRequest1.UserId);
+        var seededRequest4 = await DataGenerator.SeedVolunteerRequest(WriteDbContext);
+        
+        seededRequest1.SetOnReview(adminId);
+
+        seededRequest2.SetOnReview(adminId);
+        seededRequest2.SetRejected(adminId);
+
+        seededRequest3.SetOnReview(adminId);
+        seededRequest3.SetRejected(adminId);
+        
+        await WriteDbContext.SaveChangesAsync();
+        
+        var query = new GetRequestsByUserIdQuery(
+            seededRequest1.UserId,
+            PAGE,
+            PAGE_SIZE,
+            VolunteerRequestStatusEnum.Rejected.ToString());
+        
+        // act
+        var result = await _sut.HandleAsync(query, CancellationToken.None);
+        
+        // assert
+        result.TotalCount.Should().Be(2);
+        result.Items.Count().Should().Be(2);
+        result.Items.Should().NotContain(v => v.Id == seededRequest1.Id);
+        result.Items.Should().Contain(v => v.Id == seededRequest2.Id);
+        result.Items.Should().Contain(v => v.Id == seededRequest3.Id);
+    }
+}

--- a/PetFamily.Backend/tests/PetFamily.IntegrationTests/VolunteerRequests/HandlerTests/GetUnhandledRequestsTests.cs
+++ b/PetFamily.Backend/tests/PetFamily.IntegrationTests/VolunteerRequests/HandlerTests/GetUnhandledRequestsTests.cs
@@ -1,0 +1,52 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using PetFamily.Core.Abstractions;
+using PetFamily.Core.Dto.VolunteerRequest;
+using PetFamily.Core.Models;
+using PetFamily.IntegrationTests.General;
+using PetFamily.IntegrationTests.VolunteerRequests.Heritage;
+using PetFamily.VolunteerRequests.Application.Queries.GetUnhandledRequests;
+
+namespace PetFamily.IntegrationTests.VolunteerRequests.HandlerTests;
+
+
+public class GetUnhandledRequestsTests : VolunteerRequestsTestsBase
+{
+    private readonly IQueryHandler<PagedList<VolunteerRequestDto>, GetUnhandledRequestsQuery> _sut;
+
+    public GetUnhandledRequestsTests(VolunteerRequestsWebFactory factory) : base(factory)
+    {
+        _sut = Scope.ServiceProvider
+            .GetRequiredService<IQueryHandler<PagedList<VolunteerRequestDto>, GetUnhandledRequestsQuery>>();
+    }
+    
+    [Fact]
+    public async Task GetUnhandledRequests_should_return_3_unhandled_requests()
+    {
+        // arrange
+        var PAGE = 1;
+        var PAGE_SIZE = 3;
+        var seededRequest1 = await DataGenerator.SeedVolunteerRequest(WriteDbContext);
+        var seededRequest2 = await DataGenerator.SeedVolunteerRequest(WriteDbContext);
+        var seededRequest3 = await DataGenerator.SeedVolunteerRequest(WriteDbContext);
+        var seededRequest4 = await DataGenerator.SeedVolunteerRequest(WriteDbContext);
+        
+        var query = new GetUnhandledRequestsQuery(PAGE, PAGE_SIZE);
+        
+        // act
+        var result = await _sut.HandleAsync(query, CancellationToken.None);
+        
+        // assert
+        result.TotalCount.Should().Be(4);
+        result.Items.Count().Should().Be(3);
+        result.Items.Should().Contain(v => v.Id == seededRequest1.Id);
+        result.Items.Should().Contain(v => v.Id == seededRequest2.Id);
+        result.Items.Should().Contain(v => v.Id == seededRequest3.Id);
+        
+        // correctness of binding to DTO
+        result.Items.Should().Contain(v => v.UserId == seededRequest1.UserId);
+        result.Items.Should().Contain(v => v.Status == seededRequest1.Status.Value.ToString());
+        result.Items.Should().Contain(v => v.CreatedAt.Date == seededRequest1.CreatedAt.Date);
+        result.Items.Should().Contain(v => v.VolunteerInfo == seededRequest1.VolunteerInfo.Value);
+    }
+}

--- a/PetFamily.Backend/tests/PetFamily.IntegrationTests/VolunteerRequests/HandlerTests/RejectRequest.cs
+++ b/PetFamily.Backend/tests/PetFamily.IntegrationTests/VolunteerRequests/HandlerTests/RejectRequest.cs
@@ -1,0 +1,62 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using PetFamily.Core.Abstractions;
+using PetFamily.Discussions.Domain.Entities;
+using PetFamily.Discussions.Domain.ValueObjects;
+using PetFamily.IntegrationTests.General;
+using PetFamily.IntegrationTests.VolunteerRequests.Heritage;
+using PetFamily.SharedKernel.ValueObjects.Ids;
+using PetFamily.VolunteerRequests.Application.Commands.RejectRequest;
+using PetFamily.VolunteerRequests.Domain.ValueObjects;
+
+namespace PetFamily.IntegrationTests.VolunteerRequests.HandlerTests;
+
+
+public class RejectRequest : VolunteerRequestsTestsBase
+{
+    private readonly ICommandHandler<Guid, RejectRequestCommand> _sut;
+
+    public RejectRequest(VolunteerRequestsWebFactory factory) : base(factory)
+    {
+        _sut = Scope.ServiceProvider.GetRequiredService<ICommandHandler<Guid, RejectRequestCommand>>();
+    }
+    
+    [Fact]
+    public async Task RejectRequest_success_should_set_request_status_to_Rejected_and_set_RejectedAt_property()
+    {
+        // arrange
+        var adminId = Guid.NewGuid();
+        
+        var seededRequest = await DataGenerator.SeedVolunteerRequest(WriteDbContext);
+        seededRequest.SetOnReview(adminId);
+        await WriteDbContext.SaveChangesAsync();
+        
+        List<UserId> UserIds = [adminId, seededRequest.UserId];
+        var discussion = Discussion.Create(seededRequest.Id.Value, UserIds).Value;
+        DiscussionsDbContext.Add(discussion);
+        await DiscussionsDbContext.SaveChangesAsync();
+        
+        var command = new RejectRequestCommand(seededRequest.Id, adminId);
+        
+        // act
+        var result = await _sut.HandleAsync(command, CancellationToken.None);
+        
+        // assert
+        result.IsSuccess.Should().BeTrue();
+        var changedRequest = await WriteDbContext.VolunteerRequests
+            .FirstOrDefaultAsync(v => v.Id == seededRequest.Id);
+        changedRequest.Should().NotBeNull();
+        changedRequest.Status.Value.Should().Be(VolunteerRequestStatusEnum.Rejected);
+        
+        // rejecting should set RejectedAt property with value
+        changedRequest.RejectedAt.Should().NotBeNull();
+        
+        // should close discussion that is related to request
+        var updatedDiscussion = await DiscussionsDbContext.Discussions
+            .FirstOrDefaultAsync(d => d.Id == discussion.Id);
+        
+        updatedDiscussion.Should().NotBeNull();
+        updatedDiscussion.Status.Value.Should().Be(DiscussionStatusEnum.Closed);
+    }
+}

--- a/PetFamily.Backend/tests/PetFamily.IntegrationTests/VolunteerRequests/HandlerTests/RequireRevisionTests.cs
+++ b/PetFamily.Backend/tests/PetFamily.IntegrationTests/VolunteerRequests/HandlerTests/RequireRevisionTests.cs
@@ -1,0 +1,46 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using PetFamily.Core.Abstractions;
+using PetFamily.IntegrationTests.General;
+using PetFamily.IntegrationTests.VolunteerRequests.Heritage;
+using PetFamily.VolunteerRequests.Application.Commands.RequireRevision;
+using PetFamily.VolunteerRequests.Domain.ValueObjects;
+
+namespace PetFamily.IntegrationTests.VolunteerRequests.HandlerTests;
+
+public class RequireRevisionTests : VolunteerRequestsTestsBase
+{
+    private readonly ICommandHandler<Guid, RequireRevisionCommand> _sut;
+
+    public RequireRevisionTests(VolunteerRequestsWebFactory factory) : base(factory)
+    {
+        _sut = Scope.ServiceProvider.GetRequiredService<ICommandHandler<Guid, RequireRevisionCommand>>();
+    }
+    
+    [Fact]
+    public async Task RequireRevision_success_should_set_request_status_to_RequireRevision_and_create_comment()
+    {
+        // arrange
+        var REVISION_TEXT = "REVISION TEXT";
+        var adminId = Guid.NewGuid();
+        
+        var seededRequest = await DataGenerator.SeedVolunteerRequest(WriteDbContext);
+        seededRequest.SetOnReview(adminId);
+        
+        var command = new RequireRevisionCommand(seededRequest.Id, adminId, REVISION_TEXT);
+        
+        // act
+        var result = await _sut.HandleAsync(command, CancellationToken.None);
+        
+        // assert
+        result.IsSuccess.Should().BeTrue();
+        var changedRequest = await WriteDbContext.VolunteerRequests
+            .FirstOrDefaultAsync(v => v.Id == seededRequest.Id);
+        changedRequest.Should().NotBeNull();
+        changedRequest.Status.Value.Should().Be(VolunteerRequestStatusEnum.RevisionRequired);
+        
+        // setting request "OnReview" should create comment
+        changedRequest.RevisionComment.Value.Should().Be(REVISION_TEXT);
+    }
+}

--- a/PetFamily.Backend/tests/PetFamily.IntegrationTests/VolunteerRequests/HandlerTests/TakeRequestOnReviewTests.cs
+++ b/PetFamily.Backend/tests/PetFamily.IntegrationTests/VolunteerRequests/HandlerTests/TakeRequestOnReviewTests.cs
@@ -1,0 +1,47 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using PetFamily.Core.Abstractions;
+using PetFamily.IntegrationTests.General;
+using PetFamily.IntegrationTests.VolunteerRequests.Heritage;
+using PetFamily.VolunteerRequests.Application.Commands.TakeRequestOnReview;
+using PetFamily.VolunteerRequests.Domain.ValueObjects;
+
+namespace PetFamily.IntegrationTests.VolunteerRequests.HandlerTests;
+
+
+public class TakeRequestOnReviewTests : VolunteerRequestsTestsBase
+{
+    private readonly ICommandHandler<Guid, TakeRequestOnReviewCommand> _sut;
+
+    public TakeRequestOnReviewTests(VolunteerRequestsWebFactory factory) : base(factory)
+    {
+        _sut = Scope.ServiceProvider.GetRequiredService<ICommandHandler<Guid, TakeRequestOnReviewCommand>>();
+    }
+    
+    [Fact]
+    public async Task TakeRequestOnReview_success_should_set_request_status_to_OnReview_and_create_discussion()
+    {
+        // arrange
+        var adminId = Guid.NewGuid();
+        
+        var seededRequest = await DataGenerator.SeedVolunteerRequest(WriteDbContext);
+        
+        var command = new TakeRequestOnReviewCommand(seededRequest.Id, adminId);
+        
+        // act
+        var result = await _sut.HandleAsync(command, CancellationToken.None);
+        
+        // assert
+        result.IsSuccess.Should().BeTrue();
+        var changedRequest = await WriteDbContext.VolunteerRequests
+            .FirstOrDefaultAsync(v => v.Id == seededRequest.Id);
+        changedRequest.Should().NotBeNull();
+        changedRequest.Status.Value.Should().Be(VolunteerRequestStatusEnum.OnReview);
+        
+        // setting request "OnReview" should create discussion
+        var discussion = await DiscussionsDbContext.Discussions
+            .FirstOrDefaultAsync(d => d.RelationId == result.Value);
+        discussion.Should().NotBeNull();
+    }
+}

--- a/PetFamily.Backend/tests/PetFamily.IntegrationTests/VolunteerRequests/HandlerTests/TestsOfModelBinding.cs
+++ b/PetFamily.Backend/tests/PetFamily.IntegrationTests/VolunteerRequests/HandlerTests/TestsOfModelBinding.cs
@@ -34,14 +34,14 @@ public class TestsOfModelBinding : VolunteerRequestsTestsBase
     {
         // Arrange
         var DEFAULT_TEXT = "default text";
-        var REJECTION_TEXT = "rejection text";
+        var REVISION_TEXT = "revision text";
         var userId = UserId.NewUserId();
         var volunteerInfo = VolunteerInfo.Create(DEFAULT_TEXT).Value;
         var adminId = AdminId.NewAdminId();
-        var rejectionComment = RejectionComment.Create(REJECTION_TEXT).Value;
+        var revisionComment = RevisionComment.Create(REVISION_TEXT).Value;
         var request = new VolunteerRequest(userId, volunteerInfo);
         request.SetOnReview(adminId);
-        request.SetRevisionRequired(adminId, rejectionComment);
+        request.SetRevisionRequired(adminId, revisionComment);
         
 
         // act
@@ -57,6 +57,6 @@ public class TestsOfModelBinding : VolunteerRequestsTestsBase
         result.Status.Value.Should().Be(VolunteerRequestStatusEnum.RevisionRequired);
         result.CreatedAt.Should().BeBefore(DateTime.UtcNow);
         result.CreatedAt.Should().BeAfter(DateTime.UtcNow.AddHours(-1));
-        result.RejectionComment.Value.Should().Be(rejectionComment.Value);
+        result.RevisionComment.Value.Should().Be(revisionComment.Value);
     }
 }

--- a/PetFamily.Backend/tests/PetFamily.IntegrationTests/VolunteerRequests/Heritage/VolunteerRequestsTestsBase.cs
+++ b/PetFamily.Backend/tests/PetFamily.IntegrationTests/VolunteerRequests/Heritage/VolunteerRequestsTestsBase.cs
@@ -1,21 +1,34 @@
 using AutoFixture;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.DependencyInjection;
+using PetFamily.Accounts.Domain.DataModels;
 using PetFamily.VolunteerRequests.Infrastructure.DbContexts;
+using DiscussionsWriteDbContext = PetFamily.Discussions.Infrastructure.DbContexts.WriteDbContext;
+using AccountsDbContext = PetFamily.Accounts.Infrastructure.DbContexts.AccountsDbContext;
 
 namespace PetFamily.IntegrationTests.VolunteerRequests.Heritage;
 
 public class VolunteerRequestsTestsBase : IClassFixture<VolunteerRequestsWebFactory>, IAsyncLifetime
 {
     protected readonly WriteDbContext WriteDbContext;
+    protected readonly DiscussionsWriteDbContext DiscussionsDbContext;
     protected readonly IServiceScope Scope;
     protected readonly Fixture Fixture;
     protected readonly VolunteerRequestsWebFactory Factory;
+    protected readonly UserManager<User> UserManager;
+    protected readonly RoleManager<Role> RoleManager;
+    protected readonly AccountsDbContext AccountsDbContext;
 
     public VolunteerRequestsTestsBase(VolunteerRequestsWebFactory factory)
     {
         Factory = factory;
         Scope = factory.Services.CreateScope();
+        DiscussionsDbContext = Scope.ServiceProvider.GetRequiredService<DiscussionsWriteDbContext>();
         WriteDbContext = Scope.ServiceProvider.GetRequiredService<WriteDbContext>();
+        UserManager = Scope.ServiceProvider.GetRequiredService<UserManager<User>>();
+        RoleManager = Scope.ServiceProvider.GetRequiredService<RoleManager<Role>>();
+        AccountsDbContext = Scope.ServiceProvider.GetRequiredService<AccountsDbContext>();
+        
         Fixture = new Fixture();
     }
     

--- a/PetFamily.Backend/tests/PetFamily.IntegrationTests/VolunteerRequests/Heritage/VolunteerRequestsTestsBase.cs
+++ b/PetFamily.Backend/tests/PetFamily.IntegrationTests/VolunteerRequests/Heritage/VolunteerRequestsTestsBase.cs
@@ -2,6 +2,7 @@ using AutoFixture;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.DependencyInjection;
 using PetFamily.Accounts.Domain.DataModels;
+using PetFamily.VolunteerRequests.Application.Abstractions;
 using PetFamily.VolunteerRequests.Infrastructure.DbContexts;
 using DiscussionsWriteDbContext = PetFamily.Discussions.Infrastructure.DbContexts.WriteDbContext;
 using AccountsDbContext = PetFamily.Accounts.Infrastructure.DbContexts.AccountsDbContext;
@@ -18,6 +19,7 @@ public class VolunteerRequestsTestsBase : IClassFixture<VolunteerRequestsWebFact
     protected readonly UserManager<User> UserManager;
     protected readonly RoleManager<Role> RoleManager;
     protected readonly AccountsDbContext AccountsDbContext;
+    protected readonly IReadDbContext ReadDbContext;
 
     public VolunteerRequestsTestsBase(VolunteerRequestsWebFactory factory)
     {
@@ -25,6 +27,7 @@ public class VolunteerRequestsTestsBase : IClassFixture<VolunteerRequestsWebFact
         Scope = factory.Services.CreateScope();
         DiscussionsDbContext = Scope.ServiceProvider.GetRequiredService<DiscussionsWriteDbContext>();
         WriteDbContext = Scope.ServiceProvider.GetRequiredService<WriteDbContext>();
+        ReadDbContext = Scope.ServiceProvider.GetRequiredService<IReadDbContext>();
         UserManager = Scope.ServiceProvider.GetRequiredService<UserManager<User>>();
         RoleManager = Scope.ServiceProvider.GetRequiredService<RoleManager<Role>>();
         AccountsDbContext = Scope.ServiceProvider.GetRequiredService<AccountsDbContext>();


### PR DESCRIPTION
Реализация CQRS для модуля заявок на волонтерство.

Все 9 хэндлеров по заданию, каждый покрыт интеграционными тестами.

Запрет пользователю на отправку заявок реализовал следующим образом:
1) к агрегату "VolunteerRequest" добавил свойство DateTime? RejectedAt. По умолчанию null. Когда доменный метод агрегата устанавливает статус заявки как Rejected, то этому свойству присваивается текущее время.

2) Когда пользователь создает заявку, то в хэндлере выполнятся 2 проверки: 

3) Сначала проверится, есть ли у пользователя "активные заявки" (т.е. имеющие статус Submitted, OnReivew, RevisionRequired). Есть есть, то выдаем сообщение ошибке, что уже есть активные заявки.

4) Если нет, то проверится, есть ли у него заявки со статусом Rejected. Если есть, то среди них выберется свойство с набольшим значением RejectedAt, к нему прибавится время бана. Это время сравнится с текущим, если оно больше - пользователь получит ошибку с тем, что ему пока нельзя отправлять заявки, и выведется дата, когда он снова сможет начать их отправлять (т.е. время конца бана).

От себя еще сделал так, чтобы в хэндлерах, устанавливающих Aprroved и Rejected, закрывалась дискуссия между админом и пользователем, привязанная к закрываемой заявке. И если я правильно понял, то нам надо не просто создавать аккаунт волонтера для пользователя, нам надо не забыть добавить ему роль волонтера, это тоже сделал.

