### PR TITLE
ID-B-38

### DIFF
--- a/PetFamily.Backend/FileService/dbscript.cmd
+++ b/PetFamily.Backend/FileService/dbscript.cmd
@@ -1,0 +1,7 @@
+docker exec postgres psql -U postgres -c "DROP DATABASE IF EXISTS hangfire;"
+docker exec postgres psql -U postgres -c "CREATE DATABASE hangfire;"
+
+docker exec mongodb mongosh "mongodb://mongoadmin:mongopassword@localhost:27017/?authSource=admin" --eval "db.getSiblingDB('files_db').dropDatabase()"
+docker exec mongodb mongosh "mongodb://mongoadmin:mongopassword@localhost:27017/?authSource=admin" --eval "db = db.getSiblingDB('files_db'); db.createCollection('files')"
+
+pause

--- a/PetFamily.Backend/FileService/src/FileService/Features/TestHangfire.cs
+++ b/PetFamily.Backend/FileService/src/FileService/Features/TestHangfire.cs
@@ -18,8 +18,9 @@ public static class TestHangfire
 
     private static IResult Handler(CancellationToken cancellationToken = default)
     {
-        var jobId = BackgroundJob.Schedule<ConfirmConsistencyJob>(j => j
-            .Execute(Guid.NewGuid(), "key"), TimeSpan.FromSeconds(5));
+        var jobId = BackgroundJob.Schedule<ConfirmConsistencyJob>(j =>
+                j.Execute(Guid.NewGuid(), "key", "123", cancellationToken),
+            TimeSpan.FromSeconds(5));
 
         return CustomResponses.Ok(jobId);
     }

--- a/PetFamily.Backend/FileService/src/FileService/Features/UploadPresignedUrl.cs
+++ b/PetFamily.Backend/FileService/src/FileService/Features/UploadPresignedUrl.cs
@@ -3,6 +3,8 @@ using FileService.API.Endpoints;
 using FileService.Core.Models;
 using FileService.Infrastructure.Providers;
 using FileService.Infrastructure.Repositories;
+using FileService.Jobs;
+using Hangfire;
 
 namespace FileService.Features;
 
@@ -12,7 +14,7 @@ public static class UploadPresignedUrl
         string FileName,
         string ContentType,
         long Size);
-    
+
     public record UploadResponse(string Key, string Url);
 
     public sealed class Endpoint : IEndpoint
@@ -30,8 +32,10 @@ public static class UploadPresignedUrl
         CancellationToken cancellationToken = default)
     {
         var response = await fileProvider.GenerateUploadUrl(request);
-        
+
         var fileId = Guid.NewGuid();
+        
+        CreateJobs(fileId, response.Key, cancellationToken);
 
         var fileData = new FileData
         {
@@ -41,11 +45,20 @@ public static class UploadPresignedUrl
             ContentType = request.ContentType,
             UploadDate = DateTime.UtcNow
         };
-
+        
         await fileRepository.Add(fileData, cancellationToken);
-        
-        // TODO: place job that checks if file was actually uploaded in s3 storage, if not - delete record from mongoDB
-        
+
         return CustomResponses.Ok(response);
+    }
+
+    private static void CreateJobs(Guid fileId, string key, CancellationToken cancellationToken)
+    {
+        var clearJobId = BackgroundJob.Schedule<StoragesCleanerJob>(j =>
+                j.Execute(fileId, key, cancellationToken),
+            TimeSpan.FromHours(1));
+
+        BackgroundJob.Schedule<ConfirmConsistencyJob>(j =>
+                j.Execute(fileId, key, clearJobId, cancellationToken),
+            TimeSpan.FromHours(1));
     }
 }

--- a/PetFamily.Backend/FileService/src/FileService/Features/UploadPresignedUrl.cs
+++ b/PetFamily.Backend/FileService/src/FileService/Features/UploadPresignedUrl.cs
@@ -55,10 +55,10 @@ public static class UploadPresignedUrl
     {
         var clearJobId = BackgroundJob.Schedule<StoragesCleanerJob>(j =>
                 j.Execute(fileId, key, cancellationToken),
-            TimeSpan.FromHours(1));
+            TimeSpan.FromHours(24));
 
         BackgroundJob.Schedule<ConfirmConsistencyJob>(j =>
                 j.Execute(fileId, key, clearJobId, cancellationToken),
-            TimeSpan.FromHours(1));
+            TimeSpan.FromSeconds(60));
     }
 }

--- a/PetFamily.Backend/FileService/src/FileService/Infrastructure/Providers/FileProvider.cs
+++ b/PetFamily.Backend/FileService/src/FileService/Infrastructure/Providers/FileProvider.cs
@@ -27,6 +27,17 @@ public class FileProvider : IFileProvider
         _logger = logger;
     }
 
+    public async Task ConfirmExistence(string key)
+    {
+        var request = new GetObjectMetadataRequest
+        {
+            BucketName = BUCKET_NAME,
+            Key = key,
+        };
+        
+        await _s3Client.GetObjectMetadataAsync(request);
+    }
+
     public async Task<UploadResponse> GenerateUploadUrl(UploadPresignedUrlRequest request)
     {
         var key = $"{request.ContentType}/{Guid.NewGuid()}";
@@ -119,18 +130,19 @@ public class FileProvider : IFileProvider
 
         return metadata;
     }
-    
+
     public async Task<List<string>> DeleteFiles(
         List<string> keys,
         CancellationToken cancellationToken)
     {
         var request = new DeleteObjectsRequest();
         request.BucketName = BUCKET_NAME;
-        
+
         foreach (var key in keys)
         {
             request.AddKey(key);
         }
+
         await _s3Client.DeleteObjectsAsync(request, cancellationToken);
 
         return keys;

--- a/PetFamily.Backend/FileService/src/FileService/Infrastructure/Providers/IFileProvider.cs
+++ b/PetFamily.Backend/FileService/src/FileService/Infrastructure/Providers/IFileProvider.cs
@@ -13,7 +13,9 @@ namespace FileService.Infrastructure.Providers;
 
 public interface IFileProvider
 {
-    Task<UploadResponse> GenerateUploadUrl(UploadPresignedUrlRequest request);
+    public Task ConfirmExistence(string key);
+    
+    public Task<UploadResponse> GenerateUploadUrl(UploadPresignedUrlRequest request);
 
     public Task<Result<List<ProviderGetResponse>, Error>> GenerateGetUrls(
         List<string> keys,

--- a/PetFamily.Backend/FileService/src/FileService/Infrastructure/Repositories/FileRepository.cs
+++ b/PetFamily.Backend/FileService/src/FileService/Infrastructure/Repositories/FileRepository.cs
@@ -33,8 +33,6 @@ public class FileRepository : IFileRepository
             return Errors.General.ValueNotFound("Some of the provided IDs do not exist in the database", true);
 
         return filesData;
-
-
     }
 
     public async Task<UnitResult<Error>> DeleteMany(IEnumerable<Guid> fileIds, CancellationToken cancellationToken)
@@ -46,6 +44,18 @@ public class FileRepository : IFileRepository
             return Errors.General.Failure("failed to delete files from MongoDB");
 
         return Result.Success<Error>();
+    }
+    
+    public async Task<Result<FileData, Error>> GetByKey(
+        string key,
+        CancellationToken cancellationToken)
+    {
+        var filesData = await _dbContext.Files
+            .Find(f => f.StoragePath == key).FirstOrDefaultAsync(cancellationToken);
 
+        if (filesData is null)
+            return Errors.General.ValueNotFound("fileData with such storagePath doesn't exist in database", true);
+
+        return filesData;
     }
 }

--- a/PetFamily.Backend/FileService/src/FileService/Infrastructure/Repositories/FileRepository.cs
+++ b/PetFamily.Backend/FileService/src/FileService/Infrastructure/Repositories/FileRepository.cs
@@ -37,10 +37,13 @@ public class FileRepository : IFileRepository
 
     public async Task<UnitResult<Error>> DeleteMany(IEnumerable<Guid> fileIds, CancellationToken cancellationToken)
     {
+        var existedCount = await _dbContext.Files.CountDocumentsAsync(f =>
+            fileIds.Contains(f.Id), cancellationToken: cancellationToken);
+        
         var deleteResult = await _dbContext.Files
             .DeleteManyAsync(f => fileIds.Contains(f.Id), cancellationToken: cancellationToken);
 
-        if (deleteResult.DeletedCount != fileIds.Count())
+        if (deleteResult.DeletedCount != existedCount)
             return Errors.General.Failure("failed to delete files from MongoDB");
 
         return Result.Success<Error>();

--- a/PetFamily.Backend/FileService/src/FileService/Jobs/ConfirmConsistencyJob.cs
+++ b/PetFamily.Backend/FileService/src/FileService/Jobs/ConfirmConsistencyJob.cs
@@ -1,4 +1,4 @@
-using Amazon.S3;
+using FileService.Infrastructure.Providers;
 using FileService.Infrastructure.Repositories;
 using Hangfire;
 
@@ -7,27 +7,35 @@ namespace FileService.Jobs;
 public class ConfirmConsistencyJob
 {
     private readonly IFileRepository _fileRepository;
-    private readonly IAmazonS3 _s3Client;
+    private readonly IFileProvider _fileProvider;
     private readonly ILogger<ConfirmConsistencyJob> _logger;
 
     public ConfirmConsistencyJob(
         IFileRepository fileRepository,
-        IAmazonS3 s3Client,
+        IFileProvider fileProvider,
         ILogger<ConfirmConsistencyJob> logger)
     {
         _fileRepository = fileRepository;
-        _s3Client = s3Client;
+        _fileProvider = fileProvider;
         _logger = logger;
     }
 
-    [AutomaticRetry(Attempts = 3, DelaysInSeconds = [5, 10, 15])]
-    public async Task Execute(Guid fileId, string key)
+    [AutomaticRetry(Attempts = 4, DelaysInSeconds = [60, 3600, 21600, 57600])]
+    public async Task Execute(
+        Guid fileId,
+        string key,
+        string deleteJobId,
+        CancellationToken cancellationToken)
     {
-        _logger.LogInformation("Start ConfirmConsistencyJob with {fileId} and {key}", fileId, key);
+        _logger.LogInformation("Start ConfirmConsistencyJob with FileId = {fileId} and Key = {key}", fileId, key);
 
-        throw new Exception("bug!");
+        await _fileProvider.ConfirmExistence(key);
 
-        await Task.Delay(3000);
+        var result = await _fileRepository.Get([fileId], cancellationToken);
+        if (result.IsFailure)
+            throw new Exception(result.Error.Message);
+
+        BackgroundJob.Delete(deleteJobId);
         
         _logger.LogInformation("End ConfirmConsistencyJob");
     }

--- a/PetFamily.Backend/FileService/src/FileService/Jobs/StoragesCleanerJob.cs
+++ b/PetFamily.Backend/FileService/src/FileService/Jobs/StoragesCleanerJob.cs
@@ -1,0 +1,37 @@
+using FileService.Infrastructure.Providers;
+using FileService.Infrastructure.Repositories;
+using Hangfire;
+
+namespace FileService.Jobs;
+
+public class StoragesCleanerJob
+{
+    private readonly IFileRepository _fileRepository;
+    private readonly IFileProvider _fileProvider;
+    private readonly ILogger<StoragesCleanerJob> _logger;
+
+    public StoragesCleanerJob(
+        IFileRepository fileRepository,
+        IFileProvider fileProvider,
+        ILogger<StoragesCleanerJob> logger)
+    {
+        _fileRepository = fileRepository;
+        _fileProvider = fileProvider;
+        _logger = logger;
+    }
+
+    [AutomaticRetry(Attempts = 3, DelaysInSeconds = [86400, 86400, 86400])]
+    public async Task Execute(
+        Guid fileId,
+        string key,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Start ClearStoragesJob with fileId = {fileId} and Key = {key}", fileId, key);
+
+         await _fileRepository.DeleteMany([fileId], cancellationToken);
+         
+         await _fileProvider.DeleteFiles([key], cancellationToken);
+        
+        _logger.LogInformation("End ClearStoragesJob");
+    }
+}


### PR DESCRIPTION
Фоновые задачи для обеспечения согласованности данных.

Я сделал следующим образом, есть две фоновые задачи:
1) Для проверки данных
2) Для удаления данных

Задача для проверки данных обращается в minio и mongodb для проверки существования данных. Если смогла пройти до конца (не выкинув исключение), то значит данные согласованы и она удаляет задачу для удаления данных. Запускается несколько раз в течение суток после своего создания (если выкинула исключение в процессе своей работы).

Задача по удалению данных просто удаляет записи из minio и mongodb. Запускается спустя сутки после своего создания и далее раз в сутки в течение 3 дней (если выкинула исключение в процессе своей работы).

Для не multi-part версии тоже их добавил. При создании обычного upload-URL мы сразу записываем данные о нем в mongodb и запускаем эти 2 фоновые задачи. Идея проверки тут - что клиент загрузил файл по URL, но не отправил запрос подтверждения загрузки на сервер. Тогда в minio файл есть, но нету информации о нём в mongodb (если бы создавали запись в mongodb только в подтверждении запроса). Но в такой реализации несогласованность всё равно разрешится, и файл удалится из minio.