### PR TITLE
ID-B-42

### DIFF
--- a/PetFamily.Backend/Backend/src/Discussions/PetFamily.Discussions.Presentation/Discussions/DiscussionsController.cs
+++ b/PetFamily.Backend/Backend/src/Discussions/PetFamily.Discussions.Presentation/Discussions/DiscussionsController.cs
@@ -12,6 +12,12 @@ namespace PetFamily.Discussions.Presentation.Discussions;
 
 public class DiscussionsController : ApplicationController
 {
+    private readonly UserScopedData _userData;
+    public DiscussionsController(UserScopedData userData)
+    {
+        _userData = userData;
+    }
+    
     [Permission("discussions.GetDiscussion")]
     [HttpGet("{relationId:guid}")]
     public async Task<ActionResult<Guid>> GetDiscussion(
@@ -32,7 +38,7 @@ public class DiscussionsController : ApplicationController
         [FromServices] AddMessageHandler handler,
         CancellationToken cancellationToken)
     {
-        var command = request.ToCommand(relationId, GetUserId().Value);
+        var command = request.ToCommand(relationId, _userData.UserId);
         var result = await handler.HandleAsync(command, cancellationToken);
         return result.IsFailure ? result.Error.ToResponse() : result.ToResponse();
     }
@@ -44,7 +50,7 @@ public class DiscussionsController : ApplicationController
         [FromServices] CloseDiscussionHandler handler,
         CancellationToken cancellationToken)
     {
-        var command = new CloseDiscussionCommand(relationId, GetUserId().Value);
+        var command = new CloseDiscussionCommand(relationId, _userData.UserId);
         var result = await handler.HandleAsync(command, cancellationToken);
         return result.IsFailure ? result.Error.ToResponse() : result.ToResponse();
     }
@@ -58,7 +64,7 @@ public class DiscussionsController : ApplicationController
         [FromServices] EditMessageHandler handler,
         CancellationToken cancellationToken)
     {
-        var command = request.ToCommand(relationId, messageId, GetUserId().Value);
+        var command = request.ToCommand(relationId, messageId, _userData.UserId);
         var result = await handler.HandleAsync(command, cancellationToken);
         return result.IsFailure ? result.Error.ToResponse() : result.ToResponse();
     }
@@ -71,7 +77,7 @@ public class DiscussionsController : ApplicationController
         [FromServices] RemoveMessageHandler handler,
         CancellationToken cancellationToken)
     {
-        var command = new RemoveMessageCommand(relationId, messageId, GetUserId().Value);
+        var command = new RemoveMessageCommand(relationId, messageId, _userData.UserId);
         var result = await handler.HandleAsync(command, cancellationToken);
         return result.IsFailure ? result.Error.ToResponse() : result.ToResponse();
     }

--- a/PetFamily.Backend/Backend/src/PetFamily.Web/ApplicationConfiguration/UserDataConfigurator.cs
+++ b/PetFamily.Backend/Backend/src/PetFamily.Web/ApplicationConfiguration/UserDataConfigurator.cs
@@ -1,0 +1,23 @@
+using PetFamily.Framework;
+
+namespace PetFamily.Web.ApplicationConfiguration;
+
+public static class UserDataConfigurator
+{
+    public static IServiceCollection ConfigureUserData(this IServiceCollection services)
+    {
+        services.AddScoped<UserScopedData>(sp =>
+        {
+            var contextAccessor = sp.GetRequiredService<IHttpContextAccessor>();
+            var httpContext = contextAccessor.HttpContext;
+            var userData = new UserScopedData();
+
+            if (httpContext?.User.Identity?.IsAuthenticated ?? false)
+                userData.LoadFromClaims(httpContext.User.Claims);
+
+            return userData;
+        });
+        
+        return services;
+    }
+}

--- a/PetFamily.Backend/Backend/src/PetFamily.Web/Program.cs
+++ b/PetFamily.Backend/Backend/src/PetFamily.Web/Program.cs
@@ -21,6 +21,7 @@ builder.Services.AddConfiguredControllers();
 
 builder.Services.ConfigureAuthentication(builder.Configuration);
 builder.Services.ConfigureAuthorization();
+builder.Services.ConfigureUserData();
 
 builder.Services.AddEndpointsApiExplorer();
 

--- a/PetFamily.Backend/Backend/src/PetFamily.Web/etc/accounts.json
+++ b/PetFamily.Backend/Backend/src/PetFamily.Web/etc/accounts.json
@@ -1,7 +1,9 @@
 {
   "Permissions": {
     "Accounts" : [
-      "accounts.GetUserInfoById"
+      "accounts.GetUserInfoById",
+      "accounts.StartUploadAvatar",
+      "accounts.CompleteUploadAvatar"
     ],
     "Discussions": [
       "discussions.CloseDiscussion",
@@ -67,7 +69,9 @@
       "discussions.AddMessage",
       "discussions.RemoveMessage",
       "discussions.EditMessage",
-      "accounts.GetUserInfoById"
+      "accounts.GetUserInfoById",
+      "accounts.StartUploadAvatar",
+      "accounts.CompleteUploadAvatar"
     ],
     "Volunteer": [
       "volunteers.AddPet",
@@ -96,7 +100,9 @@
       "discussions.AddMessage",
       "discussions.RemoveMessage",
       "discussions.EditMessage",
-      "accounts.GetUserInfoById"
+      "accounts.GetUserInfoById",
+      "accounts.StartUploadAvatar",
+      "accounts.CompleteUploadAvatar"
     ],
     "Admin" : [
       "volunteers.AddPet",
@@ -134,7 +140,9 @@
       "discussions.AddMessage",
       "discussions.RemoveMessage",
       "discussions.EditMessage",
-      "accounts.GetUserInfoById"
+      "accounts.GetUserInfoById",
+      "accounts.StartUploadAvatar",
+      "accounts.CompleteUploadAvatar"
     ]
   }
 }

--- a/PetFamily.Backend/Backend/src/Shared/PetFamily.Framework/ApplicationController.cs
+++ b/PetFamily.Backend/Backend/src/Shared/PetFamily.Framework/ApplicationController.cs
@@ -1,8 +1,5 @@
-using CSharpFunctionalExtensions;
 using Microsoft.AspNetCore.Mvc;
-using PetFamily.Core;
 using PetFamily.Core.Models;
-using PetFamily.SharedKernel.CustomErrors;
 
 namespace PetFamily.Framework;
 
@@ -15,28 +12,5 @@ public abstract class ApplicationController : ControllerBase
         var envelope = Envelope.Ok(value);
         
         return new OkObjectResult(envelope);
-    }
-
-    protected Result<Guid, Error> GetUserId()
-    {
-        var claimId = HttpContext.User.Claims.FirstOrDefault(c => c.Type == CustomClaims.Id);
-        if (claimId == null)
-            return Errors.General.ValueNotFound("claimId");
-
-        var parseResult = Guid.TryParse(claimId.Value, out var userId);
-        if (!parseResult)
-            return Errors.General.ValueIsInvalid("userId");
-        
-        return userId;
-    }
-
-    protected UnitResult<Error> CheckExclusiveRole(string roleName)
-    {
-        var roles = HttpContext.User.Claims.Where(c => c.Type == CustomClaims.Role);
-        if (roles.Any(r => r.Value == roleName) && roles.Count() == 1)
-            return UnitResult.Success<Error>();
-
-        return Errors.General
-            .Conflict($"user should not have any other role then {roleName} in order to use this feature");
     }
 }

--- a/PetFamily.Backend/Backend/src/Shared/PetFamily.Framework/UserScopedData.cs
+++ b/PetFamily.Backend/Backend/src/Shared/PetFamily.Framework/UserScopedData.cs
@@ -1,0 +1,35 @@
+using System.Security.Claims;
+using CSharpFunctionalExtensions;
+using PetFamily.Core;
+using PetFamily.SharedKernel.CustomErrors;
+
+namespace PetFamily.Framework;
+
+public class UserScopedData
+{
+    public Guid UserId { get; private set; }
+    public List<string> Roles { get; } = [];
+
+    public void LoadFromClaims(IEnumerable<Claim> claims)
+    {
+        var claimId = claims.FirstOrDefault(c => c.Type == CustomClaims.Id);
+        
+        if (claimId != null && Guid.TryParse(claimId.Value, out var userId))
+            UserId = userId;
+        else
+            UserId = Guid.Empty;
+        
+        Roles.AddRange(claims
+            .Where(c => c.Type == CustomClaims.Role)
+            .Select(c => c.Value));
+    }
+    
+    public UnitResult<Error> ConfirmRoleExlusivity(string roleName)
+    {
+        if (Roles.Any(r => r == roleName) && Roles.Count == 1)
+            return UnitResult.Success<Error>();
+
+        return Errors.General
+            .Conflict($"user should not have any other role then {roleName} in order to use this feature");
+    }
+}

--- a/PetFamily.Backend/Backend/src/Volunteers/PetFamily.Volunteers.Presentation/Pets/PetsController.cs
+++ b/PetFamily.Backend/Backend/src/Volunteers/PetFamily.Volunteers.Presentation/Pets/PetsController.cs
@@ -45,6 +45,4 @@ public class PetsController : ApplicationController
         var result = await dapperHandler.HandleAsync(query, cancellationToken);
         return Ok(result);
     }
-    
-
 }

--- a/PetFamily.Backend/Backend/src/Volunteers/PetFamily.Volunteers.Presentation/Volunteers/VolunteersController.cs
+++ b/PetFamily.Backend/Backend/src/Volunteers/PetFamily.Volunteers.Presentation/Volunteers/VolunteersController.cs
@@ -22,6 +22,13 @@ namespace PetFamily.Volunteers.Presentation.Volunteers;
 
 public class VolunteersController : ApplicationController
 {
+    private readonly UserScopedData _userData;
+
+    public VolunteersController(UserScopedData userData)
+    {
+        _userData = userData;
+    }
+
     [Permission("volunteers.GetVolunteersWithPagination")]
     [HttpGet]
     public async Task<ActionResult> GetVolunteers(
@@ -53,7 +60,7 @@ public class VolunteersController : ApplicationController
         [FromServices] AddPetHandler handler,
         CancellationToken cancellationToken)
     {
-        var command = request.ToCommand(GetUserId().Value);
+        var command = request.ToCommand(_userData.UserId);
         var result = await handler.HandleAsync(command, cancellationToken);
         return result.IsFailure ? result.Error.ToResponse() : result.ToResponse();
     }
@@ -66,7 +73,7 @@ public class VolunteersController : ApplicationController
         [FromServices] StartUploadPhotosToPetHandler handler,
         CancellationToken cancellationToken)
     {
-        var command = request.ToCommand(GetUserId().Value, petId);
+        var command = request.ToCommand(_userData.UserId, petId);
         var result = await handler.HandleAsync(command, cancellationToken);
         return result.IsFailure ? result.Error.ToResponse() : result.ToResponse();
     }
@@ -79,7 +86,7 @@ public class VolunteersController : ApplicationController
         [FromServices] CompleteUploadPhotosToPetHandler handler,
         CancellationToken cancellationToken)
     {
-        var command = request.ToCommand(GetUserId().Value, petId);
+        var command = request.ToCommand(_userData.UserId, petId);
         var result = await handler.HandleAsync(command, cancellationToken);
         return result.IsFailure ? result.Error.ToResponse() : result.ToResponse();
     }
@@ -91,7 +98,7 @@ public class VolunteersController : ApplicationController
         [FromBody] UpdateMainInfoRequest request,
         CancellationToken cancellationToken)
     {
-        var command = request.ToCommand(GetUserId().Value);
+        var command = request.ToCommand(_userData.UserId);
         var result = await handler.HandleAsync(command, cancellationToken);
         return result.IsFailure ? result.Error.ToResponse() : result.ToResponse();
     }
@@ -130,7 +137,7 @@ public class VolunteersController : ApplicationController
         [FromServices] ChangePetPositionHandler handler,
         CancellationToken cancellationToken)
     {
-        var command = request.ToCommand(GetUserId().Value, petId);
+        var command = request.ToCommand(_userData.UserId, petId);
         var result = await handler.HandleAsync(command, cancellationToken);
         return result.IsFailure ? result.Error.ToResponse() : result.ToResponse();
     }
@@ -143,7 +150,7 @@ public class VolunteersController : ApplicationController
         [FromServices] UpdatePetInfoHandler handler,
         CancellationToken cancellationToken)
     {
-        var command = request.ToCommand(GetUserId().Value, petId);
+        var command = request.ToCommand(_userData.UserId, petId);
         var result = await handler.HandleAsync(command, cancellationToken);
         return result.IsFailure ? result.Error.ToResponse() : result.ToResponse();
     }
@@ -156,7 +163,7 @@ public class VolunteersController : ApplicationController
         [FromServices] UpdatePetHelpStatusHandler handler,
         CancellationToken cancellationToken)
     {
-        var command = request.ToCommand(GetUserId().Value, petId);
+        var command = request.ToCommand(_userData.UserId, petId);
         var result = await handler.HandleAsync(command, cancellationToken);
         return result.IsFailure ? result.Error.ToResponse() : result.ToResponse();
     }
@@ -169,7 +176,7 @@ public class VolunteersController : ApplicationController
         [FromServices] UpdatePetMainPhotoHandler handler,
         CancellationToken cancellationToken)
     {
-        var command = request.ToCommand(GetUserId().Value, petId);
+        var command = request.ToCommand(_userData.UserId, petId);
         var result = await handler.HandleAsync(command, cancellationToken);
         return result.IsFailure ? result.Error.ToResponse() : result.ToResponse();
     }
@@ -206,7 +213,7 @@ public class VolunteersController : ApplicationController
         [FromServices] DeletePetPhotosHandler handler,
         CancellationToken cancellationToken)
     {
-        var command = request.ToCommand(GetUserId().Value, petId);
+        var command = request.ToCommand(_userData.UserId, petId);
         var result = await handler.HandleAsync(command, cancellationToken);
         return result.IsFailure ? result.Error.ToResponse() : result.ToResponse();
     }
@@ -218,7 +225,7 @@ public class VolunteersController : ApplicationController
         [FromServices] SoftDeletePetHandler handler,
         CancellationToken cancellationToken)
     {
-        var command = new DeletePetCommand(GetUserId().Value, petId);
+        var command = new DeletePetCommand(_userData.UserId, petId);
         var result = await handler.HandleAsync(command, cancellationToken);
         return result.IsFailure ? result.Error.ToResponse() : result.ToResponse();
     }
@@ -230,7 +237,7 @@ public class VolunteersController : ApplicationController
         [FromServices] HardDeletePetHandler handler,
         CancellationToken cancellationToken)
     {
-        var command = new DeletePetCommand(GetUserId().Value, petId);
+        var command = new DeletePetCommand(_userData.UserId, petId);
         var result = await handler.HandleAsync(command, cancellationToken);
         return result.IsFailure ? result.Error.ToResponse() : result.ToResponse();
     }


### PR DESCRIPTION
Инкапсуляция взаимодействия с клеймами пользователя в классе UserScopedData.

Использовал IHttpContextAccessor для получения клеймов.
Причем логика такая: у нас все методы, имеющие атрибут "Permission", и так будут иметь корректный UserId (потому что он - часть клеймов JWT токена, которые мы же создаем и каждый раз проверяем в middleware авторизации). Т.е. не надо каждый раз руками проверять корректность клейма UserId. И даже если по какой-то неизвестной причине некорректный UserId попал дальше в хэндлер (через запрос или команду), то он должен будет пройти валидатор хэндлера.