### PR TITLE
Id b 44

### DIFF
--- a/PetFamily.Backend/Backend/src/Accounts/PetFamily.Accounts.Application/PetFamily.Accounts.Application.csproj
+++ b/PetFamily.Backend/Backend/src/Accounts/PetFamily.Accounts.Application/PetFamily.Accounts.Application.csproj
@@ -14,6 +14,7 @@
 
     <ItemGroup>
       <PackageReference Include="fileservice" Version="1.0.4" />
+      <PackageReference Include="MassTransit" Version="8.3.3" />
     </ItemGroup>
 
 </Project>

--- a/PetFamily.Backend/Backend/src/Accounts/PetFamily.Accounts.Infrastructure/Consumers/VolunteerRequestWasApprovedEventConsumer.cs
+++ b/PetFamily.Backend/Backend/src/Accounts/PetFamily.Accounts.Infrastructure/Consumers/VolunteerRequestWasApprovedEventConsumer.cs
@@ -1,0 +1,33 @@
+using MassTransit;
+using Microsoft.Extensions.Logging;
+using PetFamily.Accounts.Contracts;
+using PetFamily.Accounts.Contracts.Requests;
+using PetFamily.VolunteerRequests.Contracts.Messaging;
+
+namespace PetFamily.Accounts.Infrastructure.Consumers;
+
+public class VolunteerRequestWasApprovedEventConsumer : IConsumer<VolunteerRequestWasApprovedEvent>
+{
+    private readonly ILogger<VolunteerRequestWasApprovedEventConsumer> _logger;
+    private readonly ICreateVolunteerAccountContract _accountContract;
+
+    public VolunteerRequestWasApprovedEventConsumer(
+        ILogger<VolunteerRequestWasApprovedEventConsumer> logger,
+        ICreateVolunteerAccountContract accountContract)
+    {
+        _logger = logger;
+        _accountContract = accountContract;
+    }
+
+    public async Task Consume(ConsumeContext<VolunteerRequestWasApprovedEvent> context)
+    {
+        var request = new CreateVolunteerAccountRequest(context.Message.UserId);
+
+        var result = await _accountContract.CreateVolunteerAccountAsync(request, CancellationToken.None);
+
+        if (result.IsSuccess)
+            _logger.LogInformation("Successfully created volunteer account with accountID = {ID}", result.Value);
+        else
+            _logger.LogError("Failed to create account for user with ID = {ID}", request.UserId);
+    }
+}

--- a/PetFamily.Backend/Backend/src/Accounts/PetFamily.Accounts.Infrastructure/PetFamily.Accounts.Infrastructure.csproj
+++ b/PetFamily.Backend/Backend/src/Accounts/PetFamily.Accounts.Infrastructure/PetFamily.Accounts.Infrastructure.csproj
@@ -8,6 +8,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\..\Shared\PetFamily.Framework\PetFamily.Framework.csproj" />
+      <ProjectReference Include="..\..\VolunteerRequests\PetFamily.VolunteerRequests.Contracts\PetFamily.VolunteerRequests.Contracts.csproj" />
       <ProjectReference Include="..\PetFamily.Accounts.Application\PetFamily.Accounts.Application.csproj" />
     </ItemGroup>
 

--- a/PetFamily.Backend/Backend/src/Accounts/PetFamily.Accounts.Infrastructure/PetFamily.Accounts.Infrastructure.csproj
+++ b/PetFamily.Backend/Backend/src/Accounts/PetFamily.Accounts.Infrastructure/PetFamily.Accounts.Infrastructure.csproj
@@ -13,6 +13,7 @@
 
     <ItemGroup>
       <PackageReference Include="EFCore.NamingConventions" Version="8.0.3" />
+      <PackageReference Include="MassTransit.RabbitMQ" Version="8.3.3" />
       <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />
       <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.8" />
       <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="7.1.2" />

--- a/PetFamily.Backend/Backend/src/Discussions/PetFamily.Discussions.Application/Commands/CloseDiscussion/CloseDiscussionHandler.cs
+++ b/PetFamily.Backend/Backend/src/Discussions/PetFamily.Discussions.Application/Commands/CloseDiscussion/CloseDiscussionHandler.cs
@@ -55,7 +55,7 @@ public class CloseDiscussionHandler : ICommandHandler<Guid, CloseDiscussionComma
         
         await _unitOfWork.SaveChangesAsync(cancellationToken);
         
-        _logger.LogInformation($"Discussion with Id = {discussion.Value.Id} has been closed.");
+        _logger.LogInformation("Discussion with Id = {ID} has been closed", discussion.Value.Id.Value);
 
         return discussion.Value.Id.Value;
     }

--- a/PetFamily.Backend/Backend/src/Discussions/PetFamily.Discussions.Application/PetFamily.Discussions.Application.csproj
+++ b/PetFamily.Backend/Backend/src/Discussions/PetFamily.Discussions.Application/PetFamily.Discussions.Application.csproj
@@ -10,4 +10,8 @@
       <ProjectReference Include="..\PetFamily.Discussions.Domain\PetFamily.Discussions.Domain.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+      <PackageReference Include="MassTransit" Version="8.3.3" />
+    </ItemGroup>
+
 </Project>

--- a/PetFamily.Backend/Backend/src/Discussions/PetFamily.Discussions.Infrastructure/Consumers/VolunteerRequestWasApprovedEventConsumer.cs
+++ b/PetFamily.Backend/Backend/src/Discussions/PetFamily.Discussions.Infrastructure/Consumers/VolunteerRequestWasApprovedEventConsumer.cs
@@ -6,25 +6,25 @@ using PetFamily.VolunteerRequests.Contracts.Messaging;
 
 namespace PetFamily.Discussions.Infrastructure.Consumers;
 
-public class VolunteerRequestWasRejectedEventConsumer : IConsumer<VolunteerRequestWasRejectedEvent>
+public class VolunteerRequestWasApprovedEventConsumer : IConsumer<VolunteerRequestWasApprovedEvent>
 {
-    private readonly ILogger<VolunteerRequestWasRejectedEventConsumer> _logger;
+    private readonly ILogger<VolunteerRequestWasApprovedEventConsumer> _logger;
     private readonly ICloseDiscussionContract _discussionContract;
 
-    public VolunteerRequestWasRejectedEventConsumer(
-        ILogger<VolunteerRequestWasRejectedEventConsumer> logger,
+    public VolunteerRequestWasApprovedEventConsumer(
+        ILogger<VolunteerRequestWasApprovedEventConsumer> logger,
         ICloseDiscussionContract discussionContract)
     {
         _logger = logger;
         _discussionContract = discussionContract;
     }
 
-    public async Task Consume(ConsumeContext<VolunteerRequestWasRejectedEvent> context)
+    public async Task Consume(ConsumeContext<VolunteerRequestWasApprovedEvent> context)
     {
         var request = new CloseDiscussionRequest(context.Message.RequestId, context.Message.UserId);
 
         var result = await _discussionContract.CloseDiscussion(request, CancellationToken.None);
-        
+
         if (result.IsSuccess)
             _logger.LogInformation("Successfully closed discussion with ID = {ID}", result.Value);
         else

--- a/PetFamily.Backend/Backend/src/Discussions/PetFamily.Discussions.Infrastructure/Consumers/VolunteerRequestWasRejectedEventConsumer.cs
+++ b/PetFamily.Backend/Backend/src/Discussions/PetFamily.Discussions.Infrastructure/Consumers/VolunteerRequestWasRejectedEventConsumer.cs
@@ -1,0 +1,33 @@
+using MassTransit;
+using Microsoft.Extensions.Logging;
+using PetFamily.Discussions.Contracts;
+using PetFamily.Discussions.Contracts.Requests;
+using PetFamily.VolunteerRequests.Contracts.Messaging;
+
+namespace PetFamily.Discussions.Infrastructure.Consumers;
+
+public class VolunteerRequestWasRejectedEventConsumer : IConsumer<VolunteerRequestWasRejectedEvent>
+{
+    private readonly ILogger<VolunteerRequestWasRejectedEventConsumer> _logger;
+    private readonly ICloseDiscussionContract _discussionContract;
+
+    public VolunteerRequestWasRejectedEventConsumer(
+        ILogger<VolunteerRequestWasRejectedEventConsumer> logger,
+        ICloseDiscussionContract discussionContract)
+    {
+        _logger = logger;
+        _discussionContract = discussionContract;
+    }
+
+    public async Task Consume(ConsumeContext<VolunteerRequestWasRejectedEvent> context)
+    {
+        var request = new CloseDiscussionRequest(context.Message.RequestId, context.Message.UserId);
+
+        var result = await _discussionContract.CloseDiscussion(request, CancellationToken.None);
+        
+        if (result.IsSuccess)
+            _logger.LogInformation("Successfully closed discussion for event = \"VolunteerRequestWasRejected\"");
+        else
+            _logger.LogError("Failed to close discussion for event = \"VolunteerRequestWasRejected\"");
+    }
+}

--- a/PetFamily.Backend/Backend/src/Discussions/PetFamily.Discussions.Infrastructure/Consumers/VolunteerRequestWasTakenOnReviewEventConsumer.cs
+++ b/PetFamily.Backend/Backend/src/Discussions/PetFamily.Discussions.Infrastructure/Consumers/VolunteerRequestWasTakenOnReviewEventConsumer.cs
@@ -1,0 +1,34 @@
+using MassTransit;
+using Microsoft.Extensions.Logging;
+using PetFamily.Discussions.Contracts;
+using PetFamily.Discussions.Contracts.Requests;
+using PetFamily.VolunteerRequests.Contracts.Messaging;
+
+namespace PetFamily.Discussions.Infrastructure.Consumers;
+
+public class VolunteerRequestWasTakenOnReviewEventConsumer : IConsumer<VolunteerRequestWasTakenOnReviewEvent>
+{
+    private readonly ILogger<VolunteerRequestWasTakenOnReviewEventConsumer> _logger;
+    private readonly ICreateDiscussionContract _discussionContract;
+
+    public VolunteerRequestWasTakenOnReviewEventConsumer(
+        ILogger<VolunteerRequestWasTakenOnReviewEventConsumer> logger,
+        ICreateDiscussionContract discussionContract)
+    {
+        _logger = logger;
+        _discussionContract = discussionContract;
+    }
+
+    public async Task Consume(ConsumeContext<VolunteerRequestWasTakenOnReviewEvent> context)
+    {
+        List<Guid> userIds = [context.Message.UserId, context.Message.AdminId];
+        var request = new CreateDiscussionRequest(context.Message.RequestId, userIds);
+
+        var result = await _discussionContract.CreateDiscussion(request, CancellationToken.None);
+        
+        if (result.IsSuccess)
+            _logger.LogInformation("Successfully created discussion with ID = {ID}", result.Value);
+        else
+            _logger.LogError("Failed to create discussion for request with requestID = {ID}", request.RelationId);
+    }
+}

--- a/PetFamily.Backend/Backend/src/Discussions/PetFamily.Discussions.Infrastructure/PetFamily.Discussions.Infrastructure.csproj
+++ b/PetFamily.Backend/Backend/src/Discussions/PetFamily.Discussions.Infrastructure/PetFamily.Discussions.Infrastructure.csproj
@@ -7,11 +7,14 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\..\VolunteerRequests\PetFamily.VolunteerRequests.Contracts\PetFamily.VolunteerRequests.Contracts.csproj" />
       <ProjectReference Include="..\PetFamily.Discussions.Application\PetFamily.Discussions.Application.csproj" />
+      <ProjectReference Include="..\PetFamily.Discussions.Contracts\PetFamily.Discussions.Contracts.csproj" />
     </ItemGroup>
 
     <ItemGroup>
       <PackageReference Include="EFCore.NamingConventions" Version="8.0.3" />
+      <PackageReference Include="MassTransit.RabbitMQ" Version="8.3.3" />
       <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
       <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.8" />
     </ItemGroup>

--- a/PetFamily.Backend/Backend/src/PetFamily.Web/ApplicationConfiguration/MessageBusConfigurator.cs
+++ b/PetFamily.Backend/Backend/src/PetFamily.Web/ApplicationConfiguration/MessageBusConfigurator.cs
@@ -1,5 +1,8 @@
 using MassTransit;
 using PetFamily.Discussions.Infrastructure.Consumers;
+using VolunteerRequestWasApprovedEventAccountsConsumer =
+    PetFamily.Accounts.Infrastructure.Consumers.VolunteerRequestWasApprovedEventConsumer;
+
 
 namespace PetFamily.Web.ApplicationConfiguration;
 
@@ -12,6 +15,8 @@ public static class MessageBusConfigurator
             configure.SetKebabCaseEndpointNameFormatter();
 
             configure.AddConsumer<VolunteerRequestWasRejectedEventConsumer>();
+            configure.AddConsumer<VolunteerRequestWasApprovedEventConsumer>();
+            configure.AddConsumer<VolunteerRequestWasApprovedEventAccountsConsumer>();
 
             configure.UsingRabbitMq((context, cfg) =>
             {

--- a/PetFamily.Backend/Backend/src/PetFamily.Web/ApplicationConfiguration/MessageBusConfigurator.cs
+++ b/PetFamily.Backend/Backend/src/PetFamily.Web/ApplicationConfiguration/MessageBusConfigurator.cs
@@ -1,0 +1,29 @@
+using MassTransit;
+
+namespace PetFamily.Web.ApplicationConfiguration;
+
+public static class MessageBusConfigurator
+{
+    public static IServiceCollection AddMessageBus(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddMassTransit(configure =>
+        {
+            configure.SetKebabCaseEndpointNameFormatter();
+
+            configure.UsingRabbitMq((context, cfg) =>
+            {
+                cfg.Host(new Uri(configuration["RabbitMQ:Host"]!), h =>
+                {
+                    h.Username(configuration["RabbitMQ:UserName"]!);
+                    h.Password(configuration["RabbitMQ:Password"]!);
+                });
+
+                cfg.Durable = true;
+
+                cfg.ConfigureEndpoints(context);
+            });
+        });
+        
+        return services;
+    }
+}

--- a/PetFamily.Backend/Backend/src/PetFamily.Web/ApplicationConfiguration/MessageBusConfigurator.cs
+++ b/PetFamily.Backend/Backend/src/PetFamily.Web/ApplicationConfiguration/MessageBusConfigurator.cs
@@ -1,5 +1,6 @@
 using MassTransit;
 using PetFamily.Discussions.Infrastructure.Consumers;
+using PetFamily.Species.Infrastructure.Consumers;
 using PetFamily.Volunteers.Infrastructure.Consumers;
 using VolunteerRequestWasApprovedEventAccountsConsumer =
     PetFamily.Accounts.Infrastructure.Consumers.VolunteerRequestWasApprovedEventConsumer;
@@ -21,6 +22,7 @@ public static class MessageBusConfigurator
             configure.AddConsumer<VolunteerRequestWasTakenOnReviewEventConsumer>();
             configure.AddConsumer<BreedToPetExistenceEventConsumer>();
             configure.AddConsumer<SpeciesToPetExistenceEventConsumer>();
+            configure.AddConsumer<BreedToSpeciesExistenceEventConsumer>();
 
             configure.UsingRabbitMq((context, cfg) =>
             {

--- a/PetFamily.Backend/Backend/src/PetFamily.Web/ApplicationConfiguration/MessageBusConfigurator.cs
+++ b/PetFamily.Backend/Backend/src/PetFamily.Web/ApplicationConfiguration/MessageBusConfigurator.cs
@@ -1,5 +1,6 @@
 using MassTransit;
 using PetFamily.Discussions.Infrastructure.Consumers;
+using PetFamily.Volunteers.Infrastructure.Consumers;
 using VolunteerRequestWasApprovedEventAccountsConsumer =
     PetFamily.Accounts.Infrastructure.Consumers.VolunteerRequestWasApprovedEventConsumer;
 
@@ -18,6 +19,7 @@ public static class MessageBusConfigurator
             configure.AddConsumer<VolunteerRequestWasApprovedEventConsumer>();
             configure.AddConsumer<VolunteerRequestWasApprovedEventAccountsConsumer>();
             configure.AddConsumer<VolunteerRequestWasTakenOnReviewEventConsumer>();
+            configure.AddConsumer<BreedToPetExistenceEventConsumer>();
 
             configure.UsingRabbitMq((context, cfg) =>
             {

--- a/PetFamily.Backend/Backend/src/PetFamily.Web/ApplicationConfiguration/MessageBusConfigurator.cs
+++ b/PetFamily.Backend/Backend/src/PetFamily.Web/ApplicationConfiguration/MessageBusConfigurator.cs
@@ -17,6 +17,7 @@ public static class MessageBusConfigurator
             configure.AddConsumer<VolunteerRequestWasRejectedEventConsumer>();
             configure.AddConsumer<VolunteerRequestWasApprovedEventConsumer>();
             configure.AddConsumer<VolunteerRequestWasApprovedEventAccountsConsumer>();
+            configure.AddConsumer<VolunteerRequestWasTakenOnReviewEventConsumer>();
 
             configure.UsingRabbitMq((context, cfg) =>
             {

--- a/PetFamily.Backend/Backend/src/PetFamily.Web/ApplicationConfiguration/MessageBusConfigurator.cs
+++ b/PetFamily.Backend/Backend/src/PetFamily.Web/ApplicationConfiguration/MessageBusConfigurator.cs
@@ -1,4 +1,5 @@
 using MassTransit;
+using PetFamily.Discussions.Infrastructure.Consumers;
 
 namespace PetFamily.Web.ApplicationConfiguration;
 
@@ -9,6 +10,8 @@ public static class MessageBusConfigurator
         services.AddMassTransit(configure =>
         {
             configure.SetKebabCaseEndpointNameFormatter();
+
+            configure.AddConsumer<VolunteerRequestWasRejectedEventConsumer>();
 
             configure.UsingRabbitMq((context, cfg) =>
             {

--- a/PetFamily.Backend/Backend/src/PetFamily.Web/ApplicationConfiguration/MessageBusConfigurator.cs
+++ b/PetFamily.Backend/Backend/src/PetFamily.Web/ApplicationConfiguration/MessageBusConfigurator.cs
@@ -20,6 +20,7 @@ public static class MessageBusConfigurator
             configure.AddConsumer<VolunteerRequestWasApprovedEventAccountsConsumer>();
             configure.AddConsumer<VolunteerRequestWasTakenOnReviewEventConsumer>();
             configure.AddConsumer<BreedToPetExistenceEventConsumer>();
+            configure.AddConsumer<SpeciesToPetExistenceEventConsumer>();
 
             configure.UsingRabbitMq((context, cfg) =>
             {

--- a/PetFamily.Backend/Backend/src/PetFamily.Web/Program.cs
+++ b/PetFamily.Backend/Backend/src/PetFamily.Web/Program.cs
@@ -23,6 +23,8 @@ builder.Services.ConfigureAuthentication(builder.Configuration);
 builder.Services.ConfigureAuthorization();
 builder.Services.ConfigureUserData();
 
+builder.Services.AddMessageBus(builder.Configuration);
+
 builder.Services.AddEndpointsApiExplorer();
 
 builder.Services.AddFileHttpCommunication(builder.Configuration);

--- a/PetFamily.Backend/Backend/src/PetFamily.Web/appsettings.Docker.json
+++ b/PetFamily.Backend/Backend/src/PetFamily.Web/appsettings.Docker.json
@@ -7,29 +7,34 @@
   },
   "ConnectionStrings": {
     "Database": "Server=postgres;Port=5432;Database=pet_family;User Id=postgres;Password=postgres;",
-    "Seq" : "seq:5341"
+    "Seq": "seq:5341"
   },
-  "Minio" : {
-    "Endpoint" : "minio:9000",
-    "AccessKey" : "minioadmin",
-    "SecretKey" : "minioadmin",
-    "WithSsl" : "false"
+  "Minio": {
+    "Endpoint": "minio:9000",
+    "AccessKey": "minioadmin",
+    "SecretKey": "minioadmin",
+    "WithSsl": "false"
   },
   "Jwt": {
-    "Issuer" : "http://pet-family/api",
-    "Audience" : "http://pet-family/api",
-    "key" : "qweipfjqwioefsdfnvmiwogrqwemvxskogfqokwezxvmcsmkf",
-    "ExpiredMinutesTime" : 180
+    "Issuer": "http://pet-family/api",
+    "Audience": "http://pet-family/api",
+    "key": "qweipfjqwioefsdfnvmiwogrqwemvxskogfqokwezxvmcsmkf",
+    "ExpiredMinutesTime": 180
   },
   "RefreshSession": {
-    "ExpiredDaysTime" : 30
+    "ExpiredDaysTime": 30
   },
-  "ExpiredEntitiesDeletion" : {
-    "WorkHoursInterval" : 24,
-    "EntityExpiredDaysTime" : 30
+  "ExpiredEntitiesDeletion": {
+    "WorkHoursInterval": 24,
+    "EntityExpiredDaysTime": 30
   },
-  "FileService" : {
+  "FileService": {
     "Url": "http://fileservice:8080"
+  },
+  "RabbitMQ": {
+    "Host": "amqp://rabbitmq:5672",
+    "Username": "guest",
+    "Password": "guest"
   },
   "AllowedHosts": "*"
 }

--- a/PetFamily.Backend/Backend/src/PetFamily.Web/appsettings.json
+++ b/PetFamily.Backend/Backend/src/PetFamily.Web/appsettings.json
@@ -7,30 +7,35 @@
   },
   "ConnectionStrings": {
     "Database": "Server=localhost;Port=5432;Database=pet_family;User Id=postgres;Password=postgres;",
-    "Seq" : "localhost:5341"
+    "Seq": "localhost:5341"
   },
-  "Minio" : {
-    "Endpoint" : "localhost:9000",
-    "AccessKey" : "minioadmin",
-    "SecretKey" : "minioadmin",
-    "WithSsl" : "false"
+  "Minio": {
+    "Endpoint": "localhost:9000",
+    "AccessKey": "minioadmin",
+    "SecretKey": "minioadmin",
+    "WithSsl": "false"
   },
   "Jwt": {
-    "Issuer" : "http://pet-family/api",
-    "Audience" : "http://pet-family/api",
-    "key" : "qweipfjqwioefsdfnvmiwogrqwemvxskogfqokwezxvmcsmkf",
-    "ExpiredMinutesTime" : 180
+    "Issuer": "http://pet-family/api",
+    "Audience": "http://pet-family/api",
+    "key": "qweipfjqwioefsdfnvmiwogrqwemvxskogfqokwezxvmcsmkf",
+    "ExpiredMinutesTime": 180
   },
   "RefreshSession": {
-    "ExpiredDaysTime" : 30
+    "ExpiredDaysTime": 30
   },
-  "ExpiredEntitiesDeletion" : {
-    "WorkHoursInterval" : 24,
-    "EntityExpiredDaysTime" : 30
+  "ExpiredEntitiesDeletion": {
+    "WorkHoursInterval": 24,
+    "EntityExpiredDaysTime": 30
   },
-  "FileService" : {
+  "FileService": {
     "Url": "http://localhost:5153",
     "UrlTest": "http://localhost:8090"
+  },
+  "RabbitMQ": {
+    "Host": "amqp://localhost:5672",
+    "Username": "guest",
+    "Password": "guest"
   },
   "AllowedHosts": "*"
 }

--- a/PetFamily.Backend/Backend/src/Shared/PetFamily.SharedKernel/Abstractions/DomainEntity.cs
+++ b/PetFamily.Backend/Backend/src/Shared/PetFamily.SharedKernel/Abstractions/DomainEntity.cs
@@ -17,4 +17,7 @@ public abstract class DomainEntity<TId> : Entity<TId> where TId : IComparable<TI
     public void RemoveDomainEvent(IDomainEvent domainEvent) => _domainEvents.Remove(domainEvent);
     
     public void ClearDomainEvents() => _domainEvents.Clear();
+    
+    public void RemoveAllDomainEvents<T>() where T : IDomainEvent
+        => _domainEvents.RemoveAll(e => e is T);
 }

--- a/PetFamily.Backend/Backend/src/Shared/PetFamily.SharedKernel/Constants/DomainConstants.cs
+++ b/PetFamily.Backend/Backend/src/Shared/PetFamily.SharedKernel/Constants/DomainConstants.cs
@@ -19,4 +19,6 @@ public static class DomainConstants
     public const string PNG = "image/png";
     public const string JPG = "image/jpg";
     public const string WEBP = "image/webp";
+
+    public const string OK = "Ok";
 }

--- a/PetFamily.Backend/Backend/src/Shared/PetFamily.SharedKernel/Models/ResponseWrapper.cs
+++ b/PetFamily.Backend/Backend/src/Shared/PetFamily.SharedKernel/Models/ResponseWrapper.cs
@@ -1,0 +1,3 @@
+namespace PetFamily.SharedKernel.Models;
+
+public record ResponseWrapper(string Text);

--- a/PetFamily.Backend/Backend/src/Species/PetFamily.Species.Application/PetFamily.Species.Application.csproj
+++ b/PetFamily.Backend/Backend/src/Species/PetFamily.Species.Application/PetFamily.Species.Application.csproj
@@ -11,4 +11,8 @@
       <ProjectReference Include="..\PetFamily.Species.Domain\PetFamily.Species.Domain.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+      <PackageReference Include="MassTransit" Version="8.3.3" />
+    </ItemGroup>
+
 </Project>

--- a/PetFamily.Backend/Backend/src/Species/PetFamily.Species.Application/PetFamily.Species.Application.csproj
+++ b/PetFamily.Backend/Backend/src/Species/PetFamily.Species.Application/PetFamily.Species.Application.csproj
@@ -8,6 +8,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\..\Volunteers\PetFamily.Volunteers.Contracts\PetFamily.Volunteers.Contracts.csproj" />
+      <ProjectReference Include="..\PetFamily.Species.Contracts\PetFamily.Species.Contracts.csproj" />
       <ProjectReference Include="..\PetFamily.Species.Domain\PetFamily.Species.Domain.csproj" />
     </ItemGroup>
 

--- a/PetFamily.Backend/Backend/src/Species/PetFamily.Species.Contracts/Messaging/BreedToPetExistenceEvent.cs
+++ b/PetFamily.Backend/Backend/src/Species/PetFamily.Species.Contracts/Messaging/BreedToPetExistenceEvent.cs
@@ -1,0 +1,3 @@
+namespace PetFamily.Species.Contracts.Messaging;
+
+public record BreedToPetExistenceEvent(Guid BreedId);

--- a/PetFamily.Backend/Backend/src/Species/PetFamily.Species.Contracts/Messaging/SpeciesToPetExistenceEvent.cs
+++ b/PetFamily.Backend/Backend/src/Species/PetFamily.Species.Contracts/Messaging/SpeciesToPetExistenceEvent.cs
@@ -1,0 +1,3 @@
+namespace PetFamily.Species.Contracts.Messaging;
+
+public record SpeciesToPetExistenceEvent(Guid SpeciesId);

--- a/PetFamily.Backend/Backend/src/Species/PetFamily.Species.Infrastructure/Consumers/BreedToSpeciesExistenceEventConsumer.cs
+++ b/PetFamily.Backend/Backend/src/Species/PetFamily.Species.Infrastructure/Consumers/BreedToSpeciesExistenceEventConsumer.cs
@@ -1,0 +1,32 @@
+using MassTransit;
+using PetFamily.SharedKernel.Constants;
+using PetFamily.SharedKernel.Models;
+using PetFamily.Species.Contracts;
+using PetFamily.Species.Contracts.Requests;
+using PetFamily.Volunteers.Contracts.Messaging;
+
+namespace PetFamily.Species.Infrastructure.Consumers;
+
+public class BreedToSpeciesExistenceEventConsumer : IConsumer<BreedToSpeciesExistenceEvent>
+{
+    private readonly IBreedToSpeciesExistenceContract _contract;
+
+    public BreedToSpeciesExistenceEventConsumer(
+        IBreedToSpeciesExistenceContract contract)
+    {
+        _contract = contract;
+    }
+
+    public async Task Consume(ConsumeContext<BreedToSpeciesExistenceEvent> context)
+    {
+        var request = new BreedToSpeciesExistenceRequest(context.Message.SpeciesId, context.Message.BreedId);
+
+        var result = await _contract.BreedToSpeciesExistence(request);
+
+        var response = DomainConstants.OK;
+        if (result.IsFailure)
+            response = result.Error.Message;
+
+        await context.RespondAsync(new ResponseWrapper(response));
+    }
+}

--- a/PetFamily.Backend/Backend/src/Species/PetFamily.Species.Infrastructure/PetFamily.Species.Infrastructure.csproj
+++ b/PetFamily.Backend/Backend/src/Species/PetFamily.Species.Infrastructure/PetFamily.Species.Infrastructure.csproj
@@ -8,6 +8,7 @@
 
     <ItemGroup>
       <PackageReference Include="EFCore.NamingConventions" Version="8.0.3" />
+      <PackageReference Include="MassTransit.RabbitMQ" Version="8.3.3" />
       <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
       <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.8" />
     </ItemGroup>

--- a/PetFamily.Backend/Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/ApproveRequest/ApproveRequestHandler.cs
+++ b/PetFamily.Backend/Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/ApproveRequest/ApproveRequestHandler.cs
@@ -62,9 +62,11 @@ public class ApproveRequestHandler : ICommandHandler<Guid, ApproveRequestCommand
         if (result.IsFailure)
             return result.Error.ToErrorList();
 
-        await _publisher.PublishDomainEvents(request.Value, cancellationToken);
+        // await _publisher.PublishDomainEvents(request.Value, cancellationToken);
 
         await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+        await _publisher.PublishDomainEvents(request.Value, cancellationToken);
 
         _logger.LogInformation(
             "Admin with ID = {ID1} gave volunteer role to user with id = {ID2}", adminId.Value, request.Value.UserId);

--- a/PetFamily.Backend/Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/ApproveRequest/ApproveRequestHandler.cs
+++ b/PetFamily.Backend/Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/ApproveRequest/ApproveRequestHandler.cs
@@ -62,8 +62,6 @@ public class ApproveRequestHandler : ICommandHandler<Guid, ApproveRequestCommand
         if (result.IsFailure)
             return result.Error.ToErrorList();
 
-        // await _publisher.PublishDomainEvents(request.Value, cancellationToken);
-
         await _unitOfWork.SaveChangesAsync(cancellationToken);
 
         await _publisher.PublishDomainEvents(request.Value, cancellationToken);

--- a/PetFamily.Backend/Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/RejectRequest/RejectRequestHandler.cs
+++ b/PetFamily.Backend/Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/RejectRequest/RejectRequestHandler.cs
@@ -5,8 +5,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using PetFamily.Core.Abstractions;
 using PetFamily.Core.Extensions;
-using PetFamily.Discussions.Contracts;
-using PetFamily.Discussions.Contracts.Requests;
 using PetFamily.SharedKernel.CustomErrors;
 using PetFamily.SharedKernel.Extensions;
 using PetFamily.SharedKernel.Structs;
@@ -21,7 +19,6 @@ public class RejectRequestHandler : ICommandHandler<Guid, RejectRequestCommand>
     private readonly ILogger<RejectRequestHandler> _logger;
     private readonly IValidator<RejectRequestCommand> _validator;
     private readonly IUnitOfWork _unitOfWork;
-    private readonly ICloseDiscussionContract _discussionContract;
     private readonly IPublisher _publisher;
 
     public RejectRequestHandler(
@@ -30,14 +27,12 @@ public class RejectRequestHandler : ICommandHandler<Guid, RejectRequestCommand>
         IValidator<RejectRequestCommand> validator,
         [FromKeyedServices(UnitOfWorkSelector.VolunteerRequests)]
         IUnitOfWork unitOfWork,
-        ICloseDiscussionContract discussionContract,
         IPublisher publisher)
     {
         _volunteerRequestsRepository = volunteerRequestsRepository;
         _logger = logger;
         _validator = validator;
         _unitOfWork = unitOfWork;
-        _discussionContract = discussionContract;
         _publisher = publisher;
     }
 
@@ -67,12 +62,6 @@ public class RejectRequestHandler : ICommandHandler<Guid, RejectRequestCommand>
         
         await _unitOfWork.SaveChangesAsync(cancellationToken);
         
-        // будет отправлено в брокер
-        var closeDiscussionRequest = new CloseDiscussionRequest(request.Value.Id, adminId);
-        var discussionResult = await _discussionContract.CloseDiscussion(closeDiscussionRequest, cancellationToken);
-        //if (discussionResult.IsFailure)
-        //    return discussionResult.Error;
-
         _logger.LogInformation(
             "Admin with ID = {ID1} rejected request with ID = {ID2}", adminId.Value, requestId.Value);
 

--- a/PetFamily.Backend/Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/RejectRequest/RejectRequestHandler.cs
+++ b/PetFamily.Backend/Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/RejectRequest/RejectRequestHandler.cs
@@ -47,7 +47,7 @@ public class RejectRequestHandler : ICommandHandler<Guid, RejectRequestCommand>
         var requestId = VolunteerRequestId.Create(command.RequestId);
 
         var adminId = AdminId.Create(command.AdminId);
-        
+
         var request = await _volunteerRequestsRepository
             .GetByIdAsync(requestId, cancellationToken);
 
@@ -57,11 +57,13 @@ public class RejectRequestHandler : ICommandHandler<Guid, RejectRequestCommand>
         var result = request.Value.SetRejected(adminId);
         if (result.IsFailure)
             return result.Error.ToErrorList();
-        
-        await _publisher.PublishDomainEvents(request.Value, cancellationToken);
-        
+
+        // await _publisher.PublishDomainEvents(request.Value, cancellationToken);
+
         await _unitOfWork.SaveChangesAsync(cancellationToken);
-        
+
+        await _publisher.PublishDomainEvents(request.Value, cancellationToken);
+
         _logger.LogInformation(
             "Admin with ID = {ID1} rejected request with ID = {ID2}", adminId.Value, requestId.Value);
 

--- a/PetFamily.Backend/Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/RejectRequest/RejectRequestHandler.cs
+++ b/PetFamily.Backend/Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/RejectRequest/RejectRequestHandler.cs
@@ -58,8 +58,6 @@ public class RejectRequestHandler : ICommandHandler<Guid, RejectRequestCommand>
         if (result.IsFailure)
             return result.Error.ToErrorList();
 
-        // await _publisher.PublishDomainEvents(request.Value, cancellationToken);
-
         await _unitOfWork.SaveChangesAsync(cancellationToken);
 
         await _publisher.PublishDomainEvents(request.Value, cancellationToken);

--- a/PetFamily.Backend/Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/TakeRequestOnReview/TakeRequestOnReviewHandler.cs
+++ b/PetFamily.Backend/Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/TakeRequestOnReview/TakeRequestOnReviewHandler.cs
@@ -58,14 +58,16 @@ public class TakeRequestOnReviewHandler : ICommandHandler<Guid, TakeRequestOnRev
         var result = request.Value.SetOnReview(adminId);
         if (result.IsFailure)
             return result.Error.ToErrorList();
-        
-        if (request.Value.RevisionComment is not null) 
+
+        if (request.Value.RevisionComment is not null)
             request.Value.RemoveAllDomainEvents<VolunteerRequestWasTakenOnReviewEvent>();
-        
-        await _publisher.PublishDomainEvents(request.Value, cancellationToken);
-        
+
+        // await _publisher.PublishDomainEvents(request.Value, cancellationToken);
+
         await _unitOfWork.SaveChangesAsync(cancellationToken);
-        
+
+        await _publisher.PublishDomainEvents(request.Value, cancellationToken);
+
         _logger.LogInformation(
             "Admin with ID = {ID1} took request with {ID2} on review", adminId.Value, requestId.Value);
 

--- a/PetFamily.Backend/Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/TakeRequestOnReview/TakeRequestOnReviewHandler.cs
+++ b/PetFamily.Backend/Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/Commands/TakeRequestOnReview/TakeRequestOnReviewHandler.cs
@@ -62,8 +62,6 @@ public class TakeRequestOnReviewHandler : ICommandHandler<Guid, TakeRequestOnRev
         if (request.Value.RevisionComment is not null)
             request.Value.RemoveAllDomainEvents<VolunteerRequestWasTakenOnReviewEvent>();
 
-        // await _publisher.PublishDomainEvents(request.Value, cancellationToken);
-
         await _unitOfWork.SaveChangesAsync(cancellationToken);
 
         await _publisher.PublishDomainEvents(request.Value, cancellationToken);

--- a/PetFamily.Backend/Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/EventHandlers/VolunteerRequestWasApprovedEventHandlers/SendIntegrationEvent.cs
+++ b/PetFamily.Backend/Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/EventHandlers/VolunteerRequestWasApprovedEventHandlers/SendIntegrationEvent.cs
@@ -3,9 +3,9 @@ using MediatR;
 using Microsoft.Extensions.Logging;
 using PetFamily.VolunteerRequests.Domain.Events;
 
-namespace PetFamily.VolunteerRequests.Application.EventHandlers.VolunteerRequestWasRejectedEventHandlers;
+namespace PetFamily.VolunteerRequests.Application.EventHandlers.VolunteerRequestWasApprovedEventHandlers;
 
-public class SendIntegrationEvent : INotificationHandler<VolunteerRequestWasRejectedEvent>
+public class SendIntegrationEvent : INotificationHandler<VolunteerRequestWasApprovedEvent>
 {
     private readonly ILogger<SendIntegrationEvent> _logger;
     private readonly IPublishEndpoint _publishEndpoint;
@@ -19,13 +19,13 @@ public class SendIntegrationEvent : INotificationHandler<VolunteerRequestWasReje
         _publishEndpoint = publishEndpoint;
     }
 
-    public async Task Handle(VolunteerRequestWasRejectedEvent domainEvent, CancellationToken cancellationToken)
+    public async Task Handle(VolunteerRequestWasApprovedEvent domainEvent, CancellationToken cancellationToken)
     {
-        await _publishEndpoint.Publish(new Contracts.Messaging.VolunteerRequestWasRejectedEvent(
+        await _publishEndpoint.Publish(new Contracts.Messaging.VolunteerRequestWasApprovedEvent(
             domainEvent.UserId,
             domainEvent.AdminId,
             domainEvent.RequestId), cancellationToken);
         
-        _logger.LogInformation("Integration event \"VolunteerRequestWasRejectedEvent\" was published");
+        _logger.LogInformation("Integration event \"VolunteerRequestWasApprovedEvent\" was published");
     }
 }

--- a/PetFamily.Backend/Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/EventHandlers/VolunteerRequestWasRejectedEventHandlers/SendIntegrationEvent.cs
+++ b/PetFamily.Backend/Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/EventHandlers/VolunteerRequestWasRejectedEventHandlers/SendIntegrationEvent.cs
@@ -1,0 +1,31 @@
+using MassTransit;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using PetFamily.VolunteerRequests.Domain.Events;
+
+namespace PetFamily.VolunteerRequests.Application.EventHandlers.VolunteerRequestWasRejectedEventHandlers;
+
+public class SendIntegrationEvent : INotificationHandler<VolunteerRequestWasRejectedEvent>
+{
+    private readonly ILogger<SendIntegrationEvent> _logger;
+    private readonly IPublishEndpoint _publishEndpoint;
+
+
+    public SendIntegrationEvent(
+        ILogger<SendIntegrationEvent> logger,
+        IPublishEndpoint publishEndpoint)
+    {
+        _logger = logger;
+        _publishEndpoint = publishEndpoint;
+    }
+
+    public async Task Handle(VolunteerRequestWasRejectedEvent domainEvent, CancellationToken cancellationToken)
+    {
+        await _publishEndpoint.Publish(new Contracts.Messaging.VolunteerRequestWasRejectedEvent(
+            domainEvent.UserId,
+            domainEvent.AdminId,
+            domainEvent.RequestId), cancellationToken);
+        
+        _logger.LogInformation("Integration Event \"VolunteerRequestWasRejectedEvent\" was published");
+    }
+}

--- a/PetFamily.Backend/Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/EventHandlers/VolunteerRequestWasRejectedEventHandlers/TestEntityCreationWithFalseStatus.cs
+++ b/PetFamily.Backend/Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/EventHandlers/VolunteerRequestWasRejectedEventHandlers/TestEntityCreationWithFalseStatus.cs
@@ -4,7 +4,7 @@ using PetFamily.VolunteerRequests.Application.Abstractions;
 using PetFamily.VolunteerRequests.Domain.Entities;
 using PetFamily.VolunteerRequests.Domain.Events;
 
-namespace PetFamily.VolunteerRequests.Application.EventHandlers.VolunteerRequestWasApprovedEventHandlers;
+namespace PetFamily.VolunteerRequests.Application.EventHandlers.VolunteerRequestWasRejectedEventHandlers;
 
 
 public class TestEntityCreationWithFalseStatus : INotificationHandler<VolunteerRequestWasRejectedEvent>

--- a/PetFamily.Backend/Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/EventHandlers/VolunteerRequestWasTakenOnReviewEventHandlers/SendIntegrationEvent.cs
+++ b/PetFamily.Backend/Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/EventHandlers/VolunteerRequestWasTakenOnReviewEventHandlers/SendIntegrationEvent.cs
@@ -1,0 +1,30 @@
+using MassTransit;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using PetFamily.VolunteerRequests.Domain.Events;
+
+namespace PetFamily.VolunteerRequests.Application.EventHandlers.VolunteerRequestWasTakenOnReviewEventHandlers;
+
+public class SendIntegrationEvent : INotificationHandler<VolunteerRequestWasTakenOnReviewEvent>
+{
+    private readonly ILogger<SendIntegrationEvent> _logger;
+    private readonly IPublishEndpoint _publishEndpoint;
+    
+    public SendIntegrationEvent(
+        ILogger<SendIntegrationEvent> logger,
+        IPublishEndpoint publishEndpoint)
+    {
+        _logger = logger;
+        _publishEndpoint = publishEndpoint;
+    }
+
+    public async Task Handle(VolunteerRequestWasTakenOnReviewEvent domainEvent, CancellationToken cancellationToken)
+    {
+        await _publishEndpoint.Publish(new Contracts.Messaging.VolunteerRequestWasTakenOnReviewEvent(
+            domainEvent.UserId,
+            domainEvent.AdminId,
+            domainEvent.RequestId), cancellationToken);
+
+        _logger.LogInformation("Integration event \"VolunteerRequestWasTakenOnReviewEvent\" was published");
+    }
+}

--- a/PetFamily.Backend/Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/PetFamily.VolunteerRequests.Application.csproj
+++ b/PetFamily.Backend/Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Application/PetFamily.VolunteerRequests.Application.csproj
@@ -9,7 +9,12 @@
     <ItemGroup>
       <ProjectReference Include="..\..\Accounts\PetFamily.Accounts.Contracts\PetFamily.Accounts.Contracts.csproj" />
       <ProjectReference Include="..\..\Discussions\PetFamily.Discussions.Contracts\PetFamily.Discussions.Contracts.csproj" />
+      <ProjectReference Include="..\PetFamily.VolunteerRequests.Contracts\PetFamily.VolunteerRequests.Contracts.csproj" />
       <ProjectReference Include="..\PetFamily.VolunteerRequests.Domain\PetFamily.VolunteerRequests.Domain.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="MassTransit" Version="8.3.3" />
     </ItemGroup>
 
 </Project>

--- a/PetFamily.Backend/Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Contracts/Messaging/VolunteerRequestWasApprovedEvent.cs
+++ b/PetFamily.Backend/Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Contracts/Messaging/VolunteerRequestWasApprovedEvent.cs
@@ -1,0 +1,3 @@
+namespace PetFamily.VolunteerRequests.Contracts.Messaging;
+
+public record VolunteerRequestWasApprovedEvent(Guid UserId, Guid AdminId, Guid RequestId);

--- a/PetFamily.Backend/Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Contracts/Messaging/VolunteerRequestWasRejectedEvent.cs
+++ b/PetFamily.Backend/Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Contracts/Messaging/VolunteerRequestWasRejectedEvent.cs
@@ -1,0 +1,3 @@
+namespace PetFamily.VolunteerRequests.Contracts.Messaging;
+
+public record VolunteerRequestWasRejectedEvent(Guid UserId, Guid AdminId, Guid RequestId);

--- a/PetFamily.Backend/Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Contracts/Messaging/VolunteerRequestWasTakenOnReviewEvent.cs
+++ b/PetFamily.Backend/Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Contracts/Messaging/VolunteerRequestWasTakenOnReviewEvent.cs
@@ -1,0 +1,3 @@
+namespace PetFamily.VolunteerRequests.Contracts.Messaging;
+
+public record VolunteerRequestWasTakenOnReviewEvent(Guid UserId, Guid AdminId, Guid RequestId);

--- a/PetFamily.Backend/Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Domain/Entities/VolunteerRequest.cs
+++ b/PetFamily.Backend/Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Domain/Entities/VolunteerRequest.cs
@@ -102,7 +102,7 @@ public class VolunteerRequest : DomainEntity<VolunteerRequestId>
         Status = VolunteerRequestStatus.Create(VolunteerRequestStatusEnum.Approved).Value;
 
         // добавляем доменное событие - заявка одобрена
-        AddDomainEvent(new VolunteerRequestWasApprovedEvent(UserId));
+        AddDomainEvent(new VolunteerRequestWasApprovedEvent(UserId, adminId, Id));
 
         return UnitResult.Success<Error>();
     }

--- a/PetFamily.Backend/Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Domain/Entities/VolunteerRequest.cs
+++ b/PetFamily.Backend/Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Domain/Entities/VolunteerRequest.cs
@@ -53,6 +53,9 @@ public class VolunteerRequest : DomainEntity<VolunteerRequestId>
 
         AdminId = adminId;
         Status = VolunteerRequestStatus.Create(VolunteerRequestStatusEnum.OnReview).Value;
+        
+        // добавляем доменное событие - заявка взята на рассмотрение
+        AddDomainEvent(new VolunteerRequestWasTakenOnReviewEvent(UserId, AdminId, Id));
 
         return UnitResult.Success<Error>();
     }

--- a/PetFamily.Backend/Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Domain/Entities/VolunteerRequest.cs
+++ b/PetFamily.Backend/Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Domain/Entities/VolunteerRequest.cs
@@ -85,7 +85,7 @@ public class VolunteerRequest : DomainEntity<VolunteerRequestId>
         RejectedAt = DateTime.UtcNow;
         
         // добавляем доменное событие - заявка отклонена
-        AddDomainEvent(new VolunteerRequestWasRejectedEvent(UserId));
+        AddDomainEvent(new VolunteerRequestWasRejectedEvent(UserId, AdminId, Id));
 
         return UnitResult.Success<Error>();
     }

--- a/PetFamily.Backend/Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Domain/Events/VolunteerRequestWasApprovedEvent.cs
+++ b/PetFamily.Backend/Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Domain/Events/VolunteerRequestWasApprovedEvent.cs
@@ -3,4 +3,7 @@ using PetFamily.SharedKernel.ValueObjects.Ids;
 
 namespace PetFamily.VolunteerRequests.Domain.Events;
 
-public record VolunteerRequestWasApprovedEvent(UserId UserId) : IDomainEvent;
+public record VolunteerRequestWasApprovedEvent(
+    UserId UserId,
+    AdminId AdminId,
+    VolunteerRequestId RequestId) : IDomainEvent;

--- a/PetFamily.Backend/Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Domain/Events/VolunteerRequestWasRejectedEvent.cs
+++ b/PetFamily.Backend/Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Domain/Events/VolunteerRequestWasRejectedEvent.cs
@@ -3,4 +3,7 @@ using PetFamily.SharedKernel.ValueObjects.Ids;
 
 namespace PetFamily.VolunteerRequests.Domain.Events;
 
-public record VolunteerRequestWasRejectedEvent(UserId UserId) : IDomainEvent;
+public record VolunteerRequestWasRejectedEvent(
+    UserId UserId,
+    AdminId AdminId,
+    VolunteerRequestId RequestId) : IDomainEvent;

--- a/PetFamily.Backend/Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Domain/Events/VolunteerRequestWasTakenOnReviewEvent.cs
+++ b/PetFamily.Backend/Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Domain/Events/VolunteerRequestWasTakenOnReviewEvent.cs
@@ -1,0 +1,9 @@
+using PetFamily.SharedKernel.Abstractions;
+using PetFamily.SharedKernel.ValueObjects.Ids;
+
+namespace PetFamily.VolunteerRequests.Domain.Events;
+
+public record VolunteerRequestWasTakenOnReviewEvent(
+    UserId UserId,
+    AdminId AdminId,
+    VolunteerRequestId RequestId) : IDomainEvent;

--- a/PetFamily.Backend/Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Infrastructure/PetFamily.VolunteerRequests.Infrastructure.csproj
+++ b/PetFamily.Backend/Backend/src/VolunteerRequests/PetFamily.VolunteerRequests.Infrastructure/PetFamily.VolunteerRequests.Infrastructure.csproj
@@ -12,6 +12,7 @@
 
     <ItemGroup>
       <PackageReference Include="EFCore.NamingConventions" Version="8.0.3" />
+      <PackageReference Include="MassTransit.RabbitMQ" Version="8.3.3" />
       <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
       <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.8" />
     </ItemGroup>

--- a/PetFamily.Backend/Backend/src/Volunteers/PetFamily.Volunteers.Application/PetFamily.Volunteers.Application.csproj
+++ b/PetFamily.Backend/Backend/src/Volunteers/PetFamily.Volunteers.Application/PetFamily.Volunteers.Application.csproj
@@ -13,6 +13,7 @@
 
     <ItemGroup>
       <PackageReference Include="fileservice" Version="1.0.4" />
+      <PackageReference Include="MassTransit" Version="8.3.3" />
     </ItemGroup>
 
 </Project>

--- a/PetFamily.Backend/Backend/src/Volunteers/PetFamily.Volunteers.Application/PetFamily.Volunteers.Application.csproj
+++ b/PetFamily.Backend/Backend/src/Volunteers/PetFamily.Volunteers.Application/PetFamily.Volunteers.Application.csproj
@@ -8,6 +8,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\..\Species\PetFamily.Species.Contracts\PetFamily.Species.Contracts.csproj" />
+      <ProjectReference Include="..\PetFamily.Volunteers.Contracts\PetFamily.Volunteers.Contracts.csproj" />
       <ProjectReference Include="..\PetFamily.Volunteers.Domain\PetFamily.Volunteers.Domain.csproj" />
     </ItemGroup>
 

--- a/PetFamily.Backend/Backend/src/Volunteers/PetFamily.Volunteers.Contracts/Messaging/BreedToSpeciesExistenceEvent.cs
+++ b/PetFamily.Backend/Backend/src/Volunteers/PetFamily.Volunteers.Contracts/Messaging/BreedToSpeciesExistenceEvent.cs
@@ -1,0 +1,3 @@
+namespace PetFamily.Volunteers.Contracts.Messaging;
+
+public record BreedToSpeciesExistenceEvent(Guid SpeciesId, Guid BreedId);

--- a/PetFamily.Backend/Backend/src/Volunteers/PetFamily.Volunteers.Infrastructure/Consumers/BreedToPetExistenceEventConsumer.cs
+++ b/PetFamily.Backend/Backend/src/Volunteers/PetFamily.Volunteers.Infrastructure/Consumers/BreedToPetExistenceEventConsumer.cs
@@ -1,0 +1,32 @@
+using MassTransit;
+using PetFamily.SharedKernel.Constants;
+using PetFamily.SharedKernel.Models;
+using PetFamily.Species.Contracts.Messaging;
+using PetFamily.Volunteers.Contracts;
+using PetFamily.Volunteers.Contracts.Requests;
+
+namespace PetFamily.Volunteers.Infrastructure.Consumers;
+
+public class BreedToPetExistenceEventConsumer : IConsumer<BreedToPetExistenceEvent>
+{
+    private readonly IBreedToPetExistenceContract _contract;
+
+    public BreedToPetExistenceEventConsumer(
+       IBreedToPetExistenceContract contract)
+    {
+        _contract = contract;
+    }
+
+    public async Task Consume(ConsumeContext<BreedToPetExistenceEvent> context)
+    {
+        var request = new BreedToPetExistenceRequest(context.Message.BreedId);
+
+        var result = await _contract.BreedToPetExistence(request);
+
+        var response = DomainConstants.OK;
+        if (result.IsFailure)
+            response = result.Error.Message;
+
+        await context.RespondAsync(new ResponseWrapper(response));
+    }
+}

--- a/PetFamily.Backend/Backend/src/Volunteers/PetFamily.Volunteers.Infrastructure/Consumers/SpeciesToPetExistenceEventConsumer.cs
+++ b/PetFamily.Backend/Backend/src/Volunteers/PetFamily.Volunteers.Infrastructure/Consumers/SpeciesToPetExistenceEventConsumer.cs
@@ -1,0 +1,32 @@
+using MassTransit;
+using PetFamily.SharedKernel.Constants;
+using PetFamily.SharedKernel.Models;
+using PetFamily.Species.Contracts.Messaging;
+using PetFamily.Volunteers.Contracts;
+using PetFamily.Volunteers.Contracts.Requests;
+
+namespace PetFamily.Volunteers.Infrastructure.Consumers;
+
+public class SpeciesToPetExistenceEventConsumer : IConsumer<SpeciesToPetExistenceEvent>
+{
+    private readonly ISpeciesToPetExistenceContract _contract;
+
+    public SpeciesToPetExistenceEventConsumer(
+        ISpeciesToPetExistenceContract contract)
+    {
+        _contract = contract;
+    }
+
+    public async Task Consume(ConsumeContext<SpeciesToPetExistenceEvent> context)
+    {
+        var request = new SpeciesToPetExistenceRequest(context.Message.SpeciesId);
+
+        var result = await _contract.SpeciesToPetExistence(request);
+
+        var response = DomainConstants.OK;
+        if (result.IsFailure)
+            response = result.Error.Message;
+
+        await context.RespondAsync(new ResponseWrapper(response));
+    }
+}

--- a/PetFamily.Backend/Backend/src/Volunteers/PetFamily.Volunteers.Infrastructure/PetFamily.Volunteers.Infrastructure.csproj
+++ b/PetFamily.Backend/Backend/src/Volunteers/PetFamily.Volunteers.Infrastructure/PetFamily.Volunteers.Infrastructure.csproj
@@ -8,6 +8,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\PetFamily.Volunteers.Application\PetFamily.Volunteers.Application.csproj" />
+      <ProjectReference Include="..\PetFamily.Volunteers.Contracts\PetFamily.Volunteers.Contracts.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/PetFamily.Backend/Backend/src/Volunteers/PetFamily.Volunteers.Infrastructure/PetFamily.Volunteers.Infrastructure.csproj
+++ b/PetFamily.Backend/Backend/src/Volunteers/PetFamily.Volunteers.Infrastructure/PetFamily.Volunteers.Infrastructure.csproj
@@ -12,6 +12,7 @@
 
     <ItemGroup>
       <PackageReference Include="EFCore.NamingConventions" Version="8.0.3" />
+      <PackageReference Include="MassTransit.RabbitMQ" Version="8.3.3" />
       <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
       <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
       <PackageReference Include="Minio" Version="6.0.1" />

--- a/PetFamily.Backend/Backend/tests/PetFamily.Domain.UnitTests/VolunteerRequestsTests.cs
+++ b/PetFamily.Backend/Backend/tests/PetFamily.Domain.UnitTests/VolunteerRequestsTests.cs
@@ -491,10 +491,9 @@ public class VolunteerRequestsTests
         request.AdminId.Should().Be(adminId);
         request.Status.Value.Should().Be(VolunteerRequestStatusEnum.Approved);
 
-        var domainEvent = request.DomainEvents.SingleOrDefault() as VolunteerRequestWasApprovedEvent;
-        request.DomainEvents.SingleOrDefault().Should().NotBeNull();
-        domainEvent.Should().NotBeNull();
-        domainEvent.UserId.Should().Be(userId);
+        var domainEvents = request.DomainEvents.ToList();
+        domainEvents.Should().NotBeNull();
+        domainEvents.Count.Should().Be(2);
     }
 
     [Fact]

--- a/PetFamily.Backend/Backend/tests/PetFamily.IntegrationTests/PetFamily.IntegrationTests.csproj
+++ b/PetFamily.Backend/Backend/tests/PetFamily.IntegrationTests/PetFamily.IntegrationTests.csproj
@@ -19,6 +19,7 @@
         <PackageReference Include="NSubstitute" Version="5.3.0" />
         <PackageReference Include="Respawn" Version="6.2.1" />
         <PackageReference Include="Testcontainers.PostgreSql" Version="4.0.0" />
+        <PackageReference Include="Testcontainers.RabbitMq" Version="4.4.0" />
         <PackageReference Include="xunit" Version="2.5.3"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3"/>
     </ItemGroup>


### PR DESCRIPTION
Взаимодействие между модулями с помощью интеграционных событий.

Насчитал у нас 6 случаев, когда происходит общение через контракты:
1) Установление статуса заявки в Approved -> Надо закрыть дискуссию и создать волонтера. Следовательно 2 разных модуля (дискуссии и аккаунты) потребляют 1 событие.
2) Установление статуса заявки в Rejected -> Закрыть дискуссию. 1 потребитель
3) Установление статуса заявки в OnReview -> Создать дискуссию, если её еще нет. 1 потребитель 
Части с "закрытием дискуссий" я добавил сам, когда делал модуль заявок. Т.е. когда у заявки есть конечный статус (отклонена/принята), то дискуссия между админом и пользователем завершается.

Далее есть еще 3 случая, взаимодействие между модулем видов и модулем питомцев:

4)  Проверка существование питомцев с определенной породой -> 1 потребитель
5)  Проверка существования питомцев с определенным видом -> 1 потребитель
6)  Проверка существования пары вид-порода (для создания питомца) - 1 потребитель.

В этих случаях нам надо не просто отправлять события, но еще и ждать ответ. Обработать ошибку в случае возврата ошибки. Я посмотрел, как это сделать на сайте MassTransit и реализовал.

Еще по замечанию ID-B-43. Как я понял, имелось в виду, что мы должны публиковать интеграционные события после завершения транзакции, а не внутри неё. Но в той задаче не было интеграционных событий, поэтому я просто публиковал их прямо в транзакции. Сейчас я перенес публикацию на строчку за SaveChangesAsync в первых трех случаях, так как у нас во всех модулях есть только 1 агрегат (кроме заявок, но там он тестовый), следовательно всё, что лежит с списке событий доменной модели - интеграционные события. Хотя во всех случаях можно раскомментить и прошлый вариант - будут публиковаться прямо в транзакции, вместе с обычными доменными событиями.
